### PR TITLE
fix: pass the JWT_SECRET_KEY secret through to the Portainer stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,11 @@
 #                       Google SSO keys, ...). Written to portainer/stack.env.local
 #                       before deploying so the real app secrets reach the stack —
 #                       without it the deploy would overwrite them with placeholders.
+#
+# Optional repository secrets:
+#   JWT_SECRET_KEY      Signing key for Android app tokens, appended to the stack
+#                       env above. Unset leaves /api/mobile/* returning 503.
+#                       Generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
 
 name: Build & Deploy
 
@@ -78,12 +83,22 @@ jobs:
       - name: Write stack env from secret
         env:
           STACK_ENV_LOCAL: ${{ secrets.STACK_ENV_LOCAL }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: |
           if [[ -z "$STACK_ENV_LOCAL" ]]; then
             echo "::error::STACK_ENV_LOCAL secret is not set — see header of .github/workflows/deploy.yml"
             exit 1
           fi
           printf '%s\n' "$STACK_ENV_LOCAL" > portainer/stack.env.local
+          # Kept as its own secret so rotating it does not mean re-pasting the
+          # whole env blob. Appended last, so it wins over any JWT_SECRET_KEY in
+          # STACK_ENV_LOCAL; unset simply leaves mobile auth disabled.
+          if [[ -n "$JWT_SECRET_KEY" ]]; then
+            printf 'JWT_SECRET_KEY=%s\n' "$JWT_SECRET_KEY" >> portainer/stack.env.local
+            echo "Mobile auth: JWT_SECRET_KEY supplied"
+          else
+            echo "Mobile auth: JWT_SECRET_KEY not set — /api/mobile/* will return 503"
+          fi
 
       - name: Update srv2 stack (pull new image)
         env:


### PR DESCRIPTION
Follow-up to #15. `JWT_SECRET_KEY` was added as a repository secret, but that
alone can't reach the app.

`build_env_json` in `scripts/portainer-deploy.sh` composes the container's
environment from `portainer/stack.env` and `portainer/stack.env.local` only — it
never reads the process environment — and the deploy step passes just
`PORTAINER_URL` and `PORTAINER_API_KEY`. So the secret was silently inert:
`mobile_auth_enabled` stayed `false` with nothing in the log to say why.

This appends it to `stack.env.local` next to `STACK_ENV_LOCAL`, keeping it a
separate secret so rotating the JWT key doesn't mean re-pasting the whole env
blob. It's appended last, so it wins over any stale `JWT_SECRET_KEY` in the blob.
When unset, mobile auth stays off and the log now says so instead of leaving you
to guess.

## Test plan

- [x] Workflow YAML parses; the `run` block passes `bash -n`
- [x] Step dry-run with the secret set appends the line; with it empty, nothing is
      appended and the log says `/api/mobile/*` will return 503
- [x] Replayed the real `build_env_json` merge: appended value reaches the
      container, overrides a stale in-blob value, and no `PORTAINER_*` keys leak
      into the container environment
- [ ] Confirm `mobile_auth_enabled: true` in production after this deploys

Made with [Cursor](https://cursor.com)