### PR TITLE
feat(mobile): Authentik sign-in in the Android app

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,17 +1,94 @@
-# pickarecipe
+# Pick-a-Recipe — Android app
 
-A new Flutter project.
+Flutter client for the Pick-a-Recipe server. Signs in against the same
+Authentik tenant as the web UI and talks to the `/api/mobile/*` endpoints with
+JWT bearer tokens.
 
-## Getting Started
+## Requirements
 
-This project is a starting point for a Flutter application.
+- Flutter 3.44 or newer (stable channel)
+- A running Pick-a-Recipe server with `JWT_SECRET_KEY` set — without it the
+  mobile endpoints return 503 and sign-in cannot complete
 
-A few resources to get you started if this is your first Flutter project:
+## Running
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+The API host comes from the build flavor, so there is nothing to edit in the
+source:
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```bash
+flutter run                                        # dev: http://10.0.2.2:5006
+flutter run --dart-define=FLAVOR=prod              # https://recipes.pickel.me
+flutter run --dart-define=API_BASE_URL=http://192.168.1.10:5006   # explicit host
+```
+
+`10.0.2.2` is the Android emulator's alias for the host machine. On a physical
+device, pass `API_BASE_URL` with your machine's LAN address. Cleartext HTTP is
+permitted only for those loopback/dev hosts; see
+`android/app/src/main/res/xml/network_security_config.xml`.
+
+```bash
+flutter test
+flutter analyze
+```
+
+## How sign-in works
+
+The app never handles the OIDC client secret, and no credentials are entered
+inside the app.
+
+1. The app asks the server for an authorization URL:
+   `GET /api/mobile/auth/login-url?redirect=par://auth/callback`. The server
+   mints a single-use nonce, uses it as the OAuth `state`, and returns the
+   Authentik URL.
+2. The URL opens in the **system browser** — not a webview — so an existing
+   Authentik session cookie is reused and credential entry stays outside the
+   app.
+3. Authentik redirects to the server's own callback,
+   `https<server>/auth/callback`. The server recognises the nonce as a mobile
+   sign-in, exchanges the code for tokens using its confidential client
+   credentials, and checks the user's Authentik group.
+4. The server redirects to `par://auth/callback#access_token=…&refresh_token=…`.
+   Tokens ride in the URL **fragment**, which browsers never send to servers,
+   keeping them out of access logs and `Referer` headers.
+5. The app receives the deep link, stores the pair in the platform keystore,
+   and confirms it with `GET /api/mobile/me` before showing a signed-in UI.
+
+Because the redirect URI registered with Authentik is the server's own
+callback, **no Authentik configuration change is needed** for the app — the
+`par://` scheme is only ever seen by the device.
+
+### Tokens
+
+Access tokens last 15 minutes, refresh tokens 30 days. `AuthInterceptor`
+attaches the access token to every request and, on a 401, refreshes once and
+replays the original request, so expiry is invisible. Concurrent 401s share a
+single refresh so the rotating refresh token is not spent more than once. A
+rejected refresh clears the pair and returns the user to the login screen.
+
+Tokens live in `flutter_secure_storage`, which on Android encrypts values with
+AES-GCM under a key wrapped by RSA-OAEP in the hardware keystore. They are
+never written to shared preferences and never logged.
+
+### Deep link registration
+
+The `par://auth/callback` intent filter is declared in
+`android/app/src/main/AndroidManifest.xml`, and the server will only redirect
+to schemes listed in its `MOBILE_DEEP_LINK_SCHEMES`. Changing the scheme means
+changing both.
+
+> Custom schemes are not exclusive on Android: another installed app can
+> register `par://` and receive the redirect. Moving to verified Android App
+> Links (an `https://` callback plus a hosted `assetlinks.json`) would close
+> that gap and is tracked as follow-up work.
+
+## Layout
+
+```
+lib/src/
+  config/      build-flavor and API host resolution
+  core/        secure token storage, Dio client + auth interceptor, deep links
+  features/
+    auth/      sign-in controller, callback parsing, login screen
+    home/      signed-in landing screen
+  router.dart  go_router with auth-driven redirects
+```

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -50,5 +50,11 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Android 11+ package visibility: without this, url_launcher cannot
+             see a browser to hand the Authentik sign-in URL to. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
     </queries>
 </manifest>

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -1,15 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'core/deep_links.dart';
 import 'core/providers.dart';
+import 'features/auth/auth_controller.dart';
 import 'router.dart';
 import 'theme/app_theme.dart';
 
-class PickARecipeApp extends ConsumerWidget {
+class PickARecipeApp extends ConsumerStatefulWidget {
   const PickARecipeApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<PickARecipeApp> createState() => _PickARecipeAppState();
+}
+
+class _PickARecipeAppState extends ConsumerState<PickARecipeApp> {
+  final DeepLinkService _deepLinks = DeepLinkService();
+
+  @override
+  void initState() {
+    super.initState();
+    // Deferred so the first frame is not blocked on storage and network, and
+    // so reading providers happens outside of initState's build phase.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final AuthController auth = ref.read(authControllerProvider.notifier);
+      _deepLinks.start(auth.completeSignIn);
+      auth.restore();
+    });
+  }
+
+  @override
+  void dispose() {
+    _deepLinks.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final config = ref.watch(configProvider);
 
     return MaterialApp.router(
@@ -17,7 +44,7 @@ class PickARecipeApp extends ConsumerWidget {
       debugShowCheckedModeBanner: !config.isProd,
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
-      routerConfig: createRouter(),
+      routerConfig: ref.watch(routerProvider),
     );
   }
 }

--- a/mobile/lib/src/core/api_client.dart
+++ b/mobile/lib/src/core/api_client.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+import 'token_store.dart';
+
+/// Backend paths for the mobile auth handshake.
+const String kRefreshPath = '/api/mobile/auth/refresh';
+const String kLoginUrlPath = '/api/mobile/auth/login-url';
+const String kMobileMePath = '/api/mobile/me';
+
+/// Attaches the bearer token to outgoing requests and renews it once when the
+/// backend rejects it, so a 15-minute access token expiring mid-session is
+/// invisible to the user.
+class AuthInterceptor extends Interceptor {
+  AuthInterceptor({
+    required this._dio,
+    required this._tokenStore,
+    required this._onSignedOut,
+  });
+
+  static const String _retriedFlag = 'auth.retried';
+
+  final Dio _dio;
+  final TokenStore _tokenStore;
+  final Future<void> Function() _onSignedOut;
+
+  /// Shared across callers so a burst of parallel 401s spends one refresh
+  /// token instead of racing several and invalidating each other.
+  Future<AuthTokens?>? _inFlightRefresh;
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    // The refresh call authenticates with the refresh token in its body; an
+    // expired access token in the header would only muddy the result.
+    if (options.path != kRefreshPath) {
+      final AuthTokens? tokens = await _tokenStore.read();
+      if (tokens != null) {
+        options.headers['Authorization'] = 'Bearer ${tokens.accessToken}';
+      }
+    }
+    handler.next(options);
+  }
+
+  @override
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    final RequestOptions request = err.requestOptions;
+    final bool retryable = err.response?.statusCode == 401 &&
+        request.path != kRefreshPath &&
+        request.extra[_retriedFlag] != true;
+    if (!retryable) {
+      return handler.next(err);
+    }
+
+    final AuthTokens? tokens = await _refresh();
+    if (tokens == null) {
+      await _onSignedOut();
+      return handler.next(err);
+    }
+
+    request.extra[_retriedFlag] = true;
+    request.headers['Authorization'] = 'Bearer ${tokens.accessToken}';
+    try {
+      // fetch dispatches without re-running interceptors, so the header set
+      // above is the one that goes out.
+      handler.resolve(await _dio.fetch<dynamic>(request));
+    } on DioException catch (retryError) {
+      handler.next(retryError);
+    }
+  }
+
+  Future<AuthTokens?> _refresh() {
+    return _inFlightRefresh ??= _performRefresh().whenComplete(() {
+      _inFlightRefresh = null;
+    });
+  }
+
+  Future<AuthTokens?> _performRefresh() async {
+    final AuthTokens? current = await _tokenStore.read();
+    if (current == null) return null;
+
+    try {
+      final Response<Map<String, dynamic>> response =
+          await _dio.post<Map<String, dynamic>>(
+        kRefreshPath,
+        data: <String, String>{'refresh_token': current.refreshToken},
+      );
+      final Map<String, dynamic>? body = response.data;
+      final String? access = body?['access_token'] as String?;
+      final String? refresh = body?['refresh_token'] as String?;
+      if (access == null || refresh == null) {
+        await _tokenStore.clear();
+        return null;
+      }
+      final AuthTokens tokens =
+          AuthTokens(accessToken: access, refreshToken: refresh);
+      await _tokenStore.save(tokens);
+      return tokens;
+    } on DioException {
+      // A rejected refresh token is terminal: drop the pair so the app asks
+      // for a fresh sign-in rather than retrying a credential that is gone.
+      await _tokenStore.clear();
+      return null;
+    }
+  }
+}
+
+Dio createApiClient({
+  required String baseUrl,
+  required TokenStore tokenStore,
+  required Future<void> Function() onSignedOut,
+  HttpClientAdapter? adapter,
+}) {
+  final Dio dio = Dio(
+    BaseOptions(
+      baseUrl: baseUrl,
+      connectTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 30),
+    ),
+  );
+  if (adapter != null) {
+    dio.httpClientAdapter = adapter;
+  }
+  dio.interceptors.add(
+    AuthInterceptor(
+      dio: dio,
+      tokenStore: tokenStore,
+      onSignedOut: onSignedOut,
+    ),
+  );
+  return dio;
+}

--- a/mobile/lib/src/core/deep_links.dart
+++ b/mobile/lib/src/core/deep_links.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+
+/// Bridges incoming deep links to a callback.
+///
+/// Covers both entry points: [AppLinks.getInitialLink] for the link that cold
+/// started the app, and the stream for links delivered while it is already
+/// running (the usual case, since sign-in leaves the app in the background).
+class DeepLinkService {
+  DeepLinkService({AppLinks? appLinks}) : _appLinks = appLinks ?? AppLinks();
+
+  final AppLinks _appLinks;
+  StreamSubscription<Uri>? _subscription;
+
+  Future<void> start(void Function(Uri uri) onLink) async {
+    final Uri? initial = await _appLinks.getInitialLink();
+    if (initial != null) {
+      onLink(initial);
+    }
+    _subscription = _appLinks.uriLinkStream.listen(onLink);
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/mobile/lib/src/core/providers.dart
+++ b/mobile/lib/src/core/providers.dart
@@ -1,10 +1,48 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../config/app_config.dart';
+import '../features/auth/auth_controller.dart';
+import '../features/auth/auth_repository.dart';
+import 'api_client.dart';
+import 'token_store.dart';
 
 /// Overridden with the real [AppConfig] in main() before runApp.
 final configProvider = Provider<AppConfig>(
   (ref) => throw UnimplementedError(
     'configProvider must be overridden in main()',
   ),
+);
+
+/// Overridden in tests with an in-memory store.
+final secureStoreProvider = Provider<SecureKeyValueStore>(
+  (ref) => const KeystoreKeyValueStore(),
+);
+
+final tokenStoreProvider = Provider<TokenStore>(
+  (ref) => TokenStore(ref.watch(secureStoreProvider)),
+);
+
+/// Indirection so tests can assert which URL would have been opened without
+/// launching a real browser.
+typedef UrlLauncher = Future<bool> Function(Uri url);
+
+final urlLauncherProvider = Provider<UrlLauncher>(
+  (ref) => (Uri url) => launchUrl(url, mode: LaunchMode.externalApplication),
+);
+
+final dioProvider = Provider<Dio>((ref) {
+  return createApiClient(
+    baseUrl: ref.watch(configProvider).baseUrl,
+    tokenStore: ref.watch(tokenStoreProvider),
+    // A refresh token the server no longer honours ends the session; the
+    // router reacts to the state change and shows the login screen.
+    onSignedOut: () async =>
+        ref.read(authControllerProvider.notifier).signOut(),
+  );
+});
+
+final authRepositoryProvider = Provider<AuthRepository>(
+  (ref) => AuthRepository(ref.watch(dioProvider)),
 );

--- a/mobile/lib/src/core/token_store.dart
+++ b/mobile/lib/src/core/token_store.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Access/refresh pair issued by the backend's mobile auth endpoints.
+class AuthTokens {
+  const AuthTokens({required this.accessToken, required this.refreshToken});
+
+  final String accessToken;
+  final String refreshToken;
+}
+
+/// Narrow contract over secure storage so tests can swap in an in-memory
+/// implementation instead of driving a platform channel.
+abstract interface class SecureKeyValueStore {
+  Future<String?> read(String key);
+  Future<void> write(String key, String value);
+  Future<void> delete(String key);
+}
+
+/// Keystore-backed implementation.
+///
+/// The [AndroidOptions] defaults encrypt values with AES-GCM under a key
+/// wrapped by RSA-OAEP in the Android keystore. The old
+/// `encryptedSharedPreferences` flag is deprecated and ignored, so it is
+/// deliberately not passed.
+class KeystoreKeyValueStore implements SecureKeyValueStore {
+  const KeystoreKeyValueStore();
+
+  static const FlutterSecureStorage _storage = FlutterSecureStorage();
+
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+}
+
+/// Holds the token pair between launches.
+///
+/// Never use shared preferences for these: they are readable by anything that
+/// gains access to the app's data directory on a rooted device.
+class TokenStore {
+  const TokenStore(this._store);
+
+  static const String _accessKey = 'auth.access_token';
+  static const String _refreshKey = 'auth.refresh_token';
+
+  final SecureKeyValueStore _store;
+
+  /// Both halves are required — a lone access token cannot be renewed, and a
+  /// lone refresh token means the pair was written only partially.
+  Future<AuthTokens?> read() async {
+    final String? access = await _store.read(_accessKey);
+    final String? refresh = await _store.read(_refreshKey);
+    if (access == null || access.isEmpty) return null;
+    if (refresh == null || refresh.isEmpty) return null;
+    return AuthTokens(accessToken: access, refreshToken: refresh);
+  }
+
+  Future<void> save(AuthTokens tokens) async {
+    await _store.write(_accessKey, tokens.accessToken);
+    await _store.write(_refreshKey, tokens.refreshToken);
+  }
+
+  Future<void> clear() async {
+    await _store.delete(_accessKey);
+    await _store.delete(_refreshKey);
+  }
+}

--- a/mobile/lib/src/features/auth/auth_callback.dart
+++ b/mobile/lib/src/features/auth/auth_callback.dart
@@ -1,0 +1,73 @@
+import '../../core/token_store.dart';
+
+/// Custom scheme the backend redirects to once it has exchanged the OIDC code.
+/// Must stay in step with the intent filter in AndroidManifest.xml and the
+/// server's MOBILE_DEEP_LINK_SCHEMES.
+const String kAuthCallbackUri = 'par://auth/callback';
+
+const String _scheme = 'par';
+const String _host = 'auth';
+const String _path = '/callback';
+
+/// Result of the `par://auth/callback` deep link.
+sealed class AuthCallback {
+  const AuthCallback();
+}
+
+class AuthCallbackSuccess extends AuthCallback {
+  const AuthCallbackSuccess(this.tokens);
+
+  final AuthTokens tokens;
+}
+
+class AuthCallbackFailure extends AuthCallback {
+  const AuthCallbackFailure(this.code);
+
+  final String code;
+
+  /// The server sends machine-readable codes, so the wording lives here rather
+  /// than being parsed out of a response body.
+  String get message => switch (code) {
+        'not_authorized' =>
+          'Your account is not authorized to use Pick-a-Recipe. Ask an '
+              'administrator to add you to the right Authentik group.',
+        'server_misconfigured' =>
+          'Mobile sign-in is not configured on the server.',
+        'token_exchange_failed' =>
+          'Could not reach the identity provider. Please try again.',
+        'invalid_request' || 'invalid_grant' =>
+          'Sign-in did not complete. Please try again.',
+        'missing_tokens' =>
+          'The sign-in link did not contain any credentials.',
+        _ => 'Sign-in failed. Please try again.',
+      };
+}
+
+/// Parses an incoming deep link.
+///
+/// Returns null when [uri] is not the auth callback, so unrelated deep links
+/// (shared recipe URLs, for instance) fall through to their own handlers.
+AuthCallback? parseAuthCallback(Uri uri) {
+  if (uri.scheme.toLowerCase() != _scheme) return null;
+  if (uri.host.toLowerCase() != _host) return null;
+  if (uri.path != _path) return null;
+
+  // Tokens arrive in the fragment rather than the query string: fragments are
+  // not sent to servers and do not leak through the Referer header.
+  final Map<String, String> params = Uri.splitQueryString(uri.fragment);
+
+  final String? error = params['error'];
+  if (error != null && error.isNotEmpty) {
+    return AuthCallbackFailure(error);
+  }
+
+  final String? access = params['access_token'];
+  final String? refresh = params['refresh_token'];
+  if (access == null || access.isEmpty || refresh == null || refresh.isEmpty) {
+    return const AuthCallbackFailure('missing_tokens');
+  }
+
+  return AuthCallbackSuccess(
+    AuthTokens(accessToken: access, refreshToken: refresh),
+  );
+}

--- a/mobile/lib/src/features/auth/auth_controller.dart
+++ b/mobile/lib/src/features/auth/auth_controller.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/providers.dart';
+import '../../core/token_store.dart';
+import 'auth_callback.dart';
+import 'auth_repository.dart';
+import 'auth_state.dart';
+
+/// Drives the sign-in handshake and owns the session state the router reads.
+class AuthController extends Notifier<AuthState> {
+  @override
+  AuthState build() => const AuthState.checking();
+
+  TokenStore get _tokens => ref.read(tokenStoreProvider);
+  AuthRepository get _repository => ref.read(authRepositoryProvider);
+
+  /// Called once at startup: a stored token pair is only trusted after the
+  /// backend confirms it, so a revoked account does not linger in the UI.
+  Future<void> restore() async {
+    if (await _tokens.read() == null) {
+      state = const AuthState.signedOut();
+      return;
+    }
+    final MobileIdentity? identity = await _repository.me();
+    if (identity == null) {
+      await _tokens.clear();
+      state = const AuthState.signedOut();
+      return;
+    }
+    state = AuthState(
+      status: AuthStatus.signedIn,
+      username: identity.username,
+      isAdmin: identity.isAdmin,
+    );
+  }
+
+  /// Opens the system browser at Authentik. Control returns to the app through
+  /// the deep link handled by [completeSignIn].
+  Future<void> signIn() async {
+    if (state.isBusy) return;
+    state = state.copyWith(isBusy: true);
+
+    try {
+      final Uri url = await _repository.loginUrl(redirectUri: kAuthCallbackUri);
+      // An external browser, not a webview: it carries any existing Authentik
+      // session cookie and keeps app code away from the credential entry.
+      final bool launched = await ref.read(urlLauncherProvider)(url);
+      if (!launched) {
+        state = state.copyWith(
+          isBusy: false,
+          errorMessage: 'No browser available to complete sign-in.',
+        );
+        return;
+      }
+      // isBusy stays true: the browser is now in front of the user and the
+      // deep link is what resolves it.
+    } on AuthApiException catch (error) {
+      state = state.copyWith(isBusy: false, errorMessage: error.message);
+    }
+  }
+
+  /// Handles the `par://auth/callback` deep link. Ignores links that are not
+  /// ours so other deep links keep working.
+  Future<void> completeSignIn(Uri uri) async {
+    final AuthCallback? callback = parseAuthCallback(uri);
+    if (callback == null) return;
+
+    switch (callback) {
+      case AuthCallbackFailure(:final String message):
+        state = AuthState.signedOut(errorMessage: message);
+      case AuthCallbackSuccess(:final AuthTokens tokens):
+        await _tokens.save(tokens);
+        final MobileIdentity? identity = await _repository.me();
+        if (identity == null) {
+          await _tokens.clear();
+          state = const AuthState.signedOut(
+            errorMessage: 'Signed in, but the server rejected the session. '
+                'Please try again.',
+          );
+          return;
+        }
+        state = AuthState(
+          status: AuthStatus.signedIn,
+          username: identity.username,
+          isAdmin: identity.isAdmin,
+        );
+    }
+  }
+
+  Future<void> signOut() async {
+    await _tokens.clear();
+    state = const AuthState.signedOut();
+  }
+
+  void dismissError() {
+    if (state.errorMessage == null) return;
+    state = state.copyWith();
+  }
+}
+
+final NotifierProvider<AuthController, AuthState> authControllerProvider =
+    NotifierProvider<AuthController, AuthState>(AuthController.new);

--- a/mobile/lib/src/features/auth/auth_repository.dart
+++ b/mobile/lib/src/features/auth/auth_repository.dart
@@ -1,0 +1,80 @@
+import 'package:dio/dio.dart';
+
+import '../../core/api_client.dart';
+
+class MobileIdentity {
+  const MobileIdentity({required this.username, required this.isAdmin});
+
+  final String username;
+  final bool isAdmin;
+}
+
+/// Thrown when the backend refuses a request for a reason worth showing.
+class AuthApiException implements Exception {
+  const AuthApiException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Wraps the three `/api/mobile/*` endpoints.
+class AuthRepository {
+  const AuthRepository(this._dio);
+
+  final Dio _dio;
+
+  /// Asks the backend for an Authentik authorization URL bound to a
+  /// single-use nonce. The nonce is minted and validated server-side, so the
+  /// app never handles the OIDC client secret.
+  Future<Uri> loginUrl({required String redirectUri}) async {
+    try {
+      final Response<Map<String, dynamic>> response =
+          await _dio.get<Map<String, dynamic>>(
+        kLoginUrlPath,
+        queryParameters: <String, String>{'redirect': redirectUri},
+      );
+      final String? url = response.data?['auth_url'] as String?;
+      if (url == null || url.isEmpty) {
+        throw const AuthApiException(
+          'The server did not return a sign-in URL.',
+        );
+      }
+      return Uri.parse(url);
+    } on DioException catch (error) {
+      throw AuthApiException(_describe(error));
+    }
+  }
+
+  Future<MobileIdentity?> me() async {
+    try {
+      final Response<Map<String, dynamic>> response =
+          await _dio.get<Map<String, dynamic>>(kMobileMePath);
+      final String? username = response.data?['username'] as String?;
+      if (username == null) return null;
+      return MobileIdentity(
+        username: username,
+        isAdmin: response.data?['is_admin'] as bool? ?? false,
+      );
+    } on DioException {
+      // Includes the 401 the interceptor could not rescue: treat as signed out.
+      return null;
+    }
+  }
+
+  String _describe(DioException error) {
+    final int? status = error.response?.statusCode;
+    if (status == 503) {
+      return 'Mobile sign-in is not enabled on this server.';
+    }
+    final Object? data = error.response?.data;
+    if (data is Map && data['error'] is String) {
+      return data['error'] as String;
+    }
+    if (status != null) {
+      return 'The server rejected the sign-in request ($status).';
+    }
+    return 'Could not reach ${_dio.options.baseUrl}. Check your connection.';
+  }
+}

--- a/mobile/lib/src/features/auth/auth_state.dart
+++ b/mobile/lib/src/features/auth/auth_state.dart
@@ -1,0 +1,48 @@
+enum AuthStatus {
+  /// Stored tokens are being read and validated; shown as a splash.
+  checking,
+  signedOut,
+  signedIn,
+}
+
+class AuthState {
+  const AuthState({
+    required this.status,
+    this.username,
+    this.isAdmin = false,
+    this.isBusy = false,
+    this.errorMessage,
+  });
+
+  const AuthState.checking() : this(status: AuthStatus.checking);
+
+  const AuthState.signedOut({String? errorMessage})
+      : this(status: AuthStatus.signedOut, errorMessage: errorMessage);
+
+  final AuthStatus status;
+  final String? username;
+  final bool isAdmin;
+
+  /// True while the browser handshake is in flight, to keep the sign-in button
+  /// from being tapped twice and burning two nonces.
+  final bool isBusy;
+  final String? errorMessage;
+
+  AuthState copyWith({
+    AuthStatus? status,
+    String? username,
+    bool? isAdmin,
+    bool? isBusy,
+    String? errorMessage,
+  }) {
+    return AuthState(
+      status: status ?? this.status,
+      username: username ?? this.username,
+      isAdmin: isAdmin ?? this.isAdmin,
+      isBusy: isBusy ?? this.isBusy,
+      // Passing null clears the message, which copyWith's usual ?? idiom
+      // cannot express.
+      errorMessage: errorMessage,
+    );
+  }
+}

--- a/mobile/lib/src/features/auth/login_screen.dart
+++ b/mobile/lib/src/features/auth/login_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth_controller.dart';
+import 'auth_state.dart';
+
+class LoginScreen extends ConsumerWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AuthState auth = ref.watch(authControllerProvider);
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Icon(
+                    Icons.restaurant_menu,
+                    size: 72,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Pick-a-Recipe',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Sign in with your Authentik account to reach your recipes.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  if (auth.errorMessage != null) ...<Widget>[
+                    _ErrorBanner(message: auth.errorMessage!),
+                    const SizedBox(height: 16),
+                  ],
+                  FilledButton.icon(
+                    onPressed: auth.isBusy
+                        ? null
+                        : () => ref
+                            .read(authControllerProvider.notifier)
+                            .signIn(),
+                    icon: auth.isBusy
+                        ? const SizedBox.square(
+                            dimension: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.login),
+                    label: Text(
+                      auth.isBusy
+                          ? 'Waiting for browser\u2026'
+                          : 'Sign in with Authentik',
+                    ),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                  ),
+                  if (auth.isBusy) ...<Widget>[
+                    const SizedBox(height: 12),
+                    Text(
+                      'Finish signing in, in the browser that just opened.',
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.errorContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(Icons.error_outline, color: colors.onErrorContainer, size: 20),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: colors.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/home/home_screen.dart
+++ b/mobile/lib/src/features/home/home_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../auth/auth_controller.dart';
+import '../auth/auth_state.dart';
+
+/// Signed-in landing screen. Recipe browsing lands here in a later wave; for
+/// now it confirms the bearer token reached the backend.
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AuthState auth = ref.watch(authControllerProvider);
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pick-a-Recipe'),
+        actions: <Widget>[
+          IconButton(
+            tooltip: 'Sign out',
+            icon: const Icon(Icons.logout),
+            onPressed: () =>
+                ref.read(authControllerProvider.notifier).signOut(),
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Icon(
+              Icons.check_circle_outline,
+              size: 56,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Signed in as ${auth.username ?? 'unknown'}',
+              style: theme.textTheme.titleMedium,
+            ),
+            if (auth.isAdmin) ...<Widget>[
+              const SizedBox(height: 4),
+              Chip(
+                label: const Text('Administrator'),
+                visualDensity: VisualDensity.compact,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/router.dart
+++ b/mobile/lib/src/router.dart
@@ -1,43 +1,76 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-/// Placeholder screens — replaced by feature screens in later waves.
-class LoginScreen extends StatelessWidget {
-  const LoginScreen({super.key});
+import 'features/auth/auth_controller.dart';
+import 'features/auth/auth_state.dart';
+import 'features/auth/login_screen.dart';
+import 'features/home/home_screen.dart';
+
+/// Shown while stored tokens are checked against the backend.
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Pick-a-Recipe')),
-      body: const Center(child: Text('Login placeholder')),
+    return const Scaffold(
+      body: Center(child: CircularProgressIndicator()),
     );
   }
 }
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Pick-a-Recipe')),
-      body: const Center(child: Text('Home placeholder')),
-    );
-  }
+/// go_router only accepts a [Listenable], so auth changes are republished as
+/// one. Subclassed because [ChangeNotifier.notifyListeners] is protected.
+class _AuthRefreshNotifier extends ChangeNotifier {
+  void ping() => notifyListeners();
 }
 
-GoRouter createRouter() {
+final Provider<GoRouter> routerProvider = Provider<GoRouter>((Ref ref) {
+  final _AuthRefreshNotifier refresh = _AuthRefreshNotifier();
+  ref.listen<AuthState>(
+    authControllerProvider,
+    (AuthState? previous, AuthState next) {
+      // Only status moves change routing; error and busy flags are rendered
+      // in place and must not re-run redirects.
+      if (previous?.status != next.status) {
+        refresh.ping();
+      }
+    },
+  );
+  ref.onDispose(refresh.dispose);
+
   return GoRouter(
-    initialLocation: '/home',
-    routes: [
+    initialLocation: '/',
+    refreshListenable: refresh,
+    redirect: (BuildContext context, GoRouterState state) {
+      final AuthStatus status = ref.read(authControllerProvider).status;
+      final String location = state.matchedLocation;
+
+      return switch (status) {
+        AuthStatus.checking => location == '/' ? null : '/',
+        AuthStatus.signedOut => location == '/login' ? null : '/login',
+        // Only bounce off the pre-auth routes, so screens added later stay
+        // reachable without touching this switch.
+        AuthStatus.signedIn =>
+          location == '/' || location == '/login' ? '/home' : null,
+      };
+    },
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (BuildContext context, GoRouterState state) =>
+            const SplashScreen(),
+      ),
       GoRoute(
         path: '/login',
-        builder: (context, state) => const LoginScreen(),
+        builder: (BuildContext context, GoRouterState state) =>
+            const LoginScreen(),
       ),
       GoRoute(
         path: '/home',
-        builder: (context, state) => const HomeScreen(),
+        builder: (BuildContext context, GoRouterState state) =>
+            const HomeScreen(),
       ),
     ],
   );
-}
+});

--- a/mobile/test/auth_callback_test.dart
+++ b/mobile/test/auth_callback_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickarecipe/src/features/auth/auth_callback.dart';
+
+void main() {
+  group('parseAuthCallback', () {
+    test('extracts the token pair from the fragment', () {
+      final AuthCallback? result = parseAuthCallback(
+        Uri.parse(
+          'par://auth/callback#access_token=aaa&refresh_token=rrr'
+          '&token_type=Bearer&expires_in=900',
+        ),
+      );
+
+      expect(result, isA<AuthCallbackSuccess>());
+      final AuthCallbackSuccess success = result! as AuthCallbackSuccess;
+      expect(success.tokens.accessToken, 'aaa');
+      expect(success.tokens.refreshToken, 'rrr');
+    });
+
+    test('percent-encoded token values survive the round trip', () {
+      final AuthCallback? result = parseAuthCallback(
+        Uri.parse(
+          'par://auth/callback#access_token=a%2Bb%2Fc%3D&refresh_token=r%2Bs',
+        ),
+      );
+
+      final AuthCallbackSuccess success = result! as AuthCallbackSuccess;
+      expect(success.tokens.accessToken, 'a+b/c=');
+      expect(success.tokens.refreshToken, 'r+s');
+    });
+
+    test('surfaces a server error code with readable copy', () {
+      final AuthCallback? result =
+          parseAuthCallback(Uri.parse('par://auth/callback#error=not_authorized'));
+
+      expect(result, isA<AuthCallbackFailure>());
+      final AuthCallbackFailure failure = result! as AuthCallbackFailure;
+      expect(failure.code, 'not_authorized');
+      expect(failure.message, contains('not authorized'));
+    });
+
+    test('unknown error codes still produce a usable message', () {
+      final AuthCallbackFailure failure = parseAuthCallback(
+        Uri.parse('par://auth/callback#error=something_new'),
+      )! as AuthCallbackFailure;
+
+      expect(failure.message, isNotEmpty);
+      expect(failure.message, isNot(contains('something_new')));
+    });
+
+    test('a fragment with neither tokens nor error is a failure', () {
+      final AuthCallback? result =
+          parseAuthCallback(Uri.parse('par://auth/callback'));
+
+      expect((result! as AuthCallbackFailure).code, 'missing_tokens');
+    });
+
+    test('half a token pair is rejected rather than half-stored', () {
+      final AuthCallback? result = parseAuthCallback(
+        Uri.parse('par://auth/callback#access_token=aaa'),
+      );
+
+      expect((result! as AuthCallbackFailure).code, 'missing_tokens');
+    });
+
+    test('returns null for deep links that are not the auth callback', () {
+      // Must stay null so unrelated deep links reach their own handlers.
+      expect(parseAuthCallback(Uri.parse('par://recipes/42')), isNull);
+      expect(parseAuthCallback(Uri.parse('https://auth/callback')), isNull);
+      expect(parseAuthCallback(Uri.parse('par://auth/other')), isNull);
+    });
+
+    test('scheme and host matching is case-insensitive', () {
+      // Android can hand back a normalised or upper-cased authority.
+      final AuthCallback? result = parseAuthCallback(
+        Uri.parse('PAR://AUTH/callback#access_token=a&refresh_token=r'),
+      );
+
+      expect(result, isA<AuthCallbackSuccess>());
+    });
+
+    test('the advertised callback constant is the one that parses', () {
+      // Guards against the constant and the matcher drifting apart.
+      expect(
+        parseAuthCallback(Uri.parse('$kAuthCallbackUri#error=x')),
+        isA<AuthCallbackFailure>(),
+      );
+    });
+  });
+}

--- a/mobile/test/auth_controller_test.dart
+++ b/mobile/test/auth_controller_test.dart
@@ -1,0 +1,268 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickarecipe/src/core/api_client.dart';
+import 'package:pickarecipe/src/core/providers.dart';
+import 'package:pickarecipe/src/core/token_store.dart';
+import 'package:pickarecipe/src/features/auth/auth_callback.dart';
+import 'package:pickarecipe/src/features/auth/auth_controller.dart';
+import 'package:pickarecipe/src/features/auth/auth_state.dart';
+
+import 'support/fakes.dart';
+
+void main() {
+  late FakeSecureStore secureStore;
+  late List<Uri> launched;
+
+  setUp(() {
+    secureStore = FakeSecureStore();
+    launched = <Uri>[];
+  });
+
+  /// Builds a container wired to canned HTTP replies and a recording launcher.
+  ProviderContainer harness(
+    Map<String, List<FakeReply>> replies, {
+    bool launchSucceeds = true,
+  }) {
+    final FakeAdapter adapter = FakeAdapter(replies);
+    final ProviderContainer container = ProviderContainer(
+      overrides: [
+        secureStoreProvider.overrideWithValue(secureStore),
+        urlLauncherProvider.overrideWithValue((Uri url) async {
+          launched.add(url);
+          return launchSucceeds;
+        }),
+        dioProvider.overrideWith(
+          (Ref ref) => createApiClient(
+            baseUrl: 'https://recipes.example.com',
+            tokenStore: ref.watch(tokenStoreProvider),
+            onSignedOut: () async =>
+                ref.read(authControllerProvider.notifier).signOut(),
+            adapter: adapter,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  AuthController controllerOf(ProviderContainer c) =>
+      c.read(authControllerProvider.notifier);
+  AuthState stateOf(ProviderContainer c) => c.read(authControllerProvider);
+
+  Future<void> seed(ProviderContainer c) => c.read(tokenStoreProvider).save(
+        const AuthTokens(accessToken: 'access-1', refreshToken: 'refresh-1'),
+      );
+
+  group('signIn', () {
+    test('launches the URL the backend hands back', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kLoginUrlPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'auth_url': 'https://id.example.com/authorize?state=nonce-1',
+          }),
+        ],
+      });
+
+      await controllerOf(c).signIn();
+
+      expect(launched.single.toString(),
+          'https://id.example.com/authorize?state=nonce-1');
+      // Stays busy: the browser is in front of the user until the deep link.
+      expect(stateOf(c).isBusy, isTrue);
+      expect(stateOf(c).errorMessage, isNull);
+    });
+
+    test('asks for the deep link the manifest actually registers', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kLoginUrlPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'auth_url': 'https://id.example.com/authorize',
+          }),
+        ],
+      });
+
+      await controllerOf(c).signIn();
+
+      expect(kAuthCallbackUri, 'par://auth/callback');
+    });
+
+    test('explains a server without mobile auth enabled', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kLoginUrlPath: <FakeReply>[const FakeReply(503)],
+      });
+
+      await controllerOf(c).signIn();
+
+      expect(stateOf(c).isBusy, isFalse);
+      expect(stateOf(c).errorMessage, contains('not enabled'));
+      expect(launched, isEmpty);
+    });
+
+    test('reports when no browser could be opened', () async {
+      final ProviderContainer c = harness(
+        <String, List<FakeReply>>{
+          kLoginUrlPath: <FakeReply>[
+            const FakeReply(200, <String, dynamic>{
+              'auth_url': 'https://id.example.com/authorize',
+            }),
+          ],
+        },
+        launchSucceeds: false,
+      );
+
+      await controllerOf(c).signIn();
+
+      expect(stateOf(c).isBusy, isFalse);
+      expect(stateOf(c).errorMessage, contains('No browser'));
+    });
+
+    test('a second tap while busy does not burn another nonce', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kLoginUrlPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'auth_url': 'https://id.example.com/authorize',
+          }),
+        ],
+      });
+
+      await controllerOf(c).signIn();
+      await controllerOf(c).signIn();
+
+      expect(launched, hasLength(1));
+    });
+  });
+
+  group('completeSignIn', () {
+    test('stores the tokens and adopts the confirmed identity', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kMobileMePath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'username': 'ada',
+            'is_admin': true,
+          }),
+        ],
+      });
+
+      await controllerOf(c).completeSignIn(
+        Uri.parse('par://auth/callback#access_token=a1&refresh_token=r1'),
+      );
+
+      final AuthState state = stateOf(c);
+      expect(state.status, AuthStatus.signedIn);
+      expect(state.username, 'ada');
+      expect(state.isAdmin, isTrue);
+      final AuthTokens? stored = await c.read(tokenStoreProvider).read();
+      expect(stored?.accessToken, 'a1');
+    });
+
+    test('shows the server error and stores nothing', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{});
+
+      await controllerOf(c).completeSignIn(
+        Uri.parse('par://auth/callback#error=not_authorized'),
+      );
+
+      expect(stateOf(c).status, AuthStatus.signedOut);
+      expect(stateOf(c).errorMessage, contains('not authorized'));
+      expect(secureStore.values, isEmpty);
+    });
+
+    test('discards tokens the server will not vouch for', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kMobileMePath: <FakeReply>[const FakeReply(401)],
+        kRefreshPath: <FakeReply>[const FakeReply(401)],
+      });
+
+      await controllerOf(c).completeSignIn(
+        Uri.parse('par://auth/callback#access_token=a1&refresh_token=r1'),
+      );
+
+      expect(stateOf(c).status, AuthStatus.signedOut);
+      expect(await c.read(tokenStoreProvider).read(), isNull);
+    });
+
+    test('ignores deep links that are not the auth callback', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{});
+      final AuthStatus before = stateOf(c).status;
+
+      await controllerOf(c).completeSignIn(Uri.parse('par://recipes/42'));
+
+      expect(stateOf(c).status, before);
+      expect(secureStore.values, isEmpty);
+    });
+  });
+
+  group('restore', () {
+    test('with no stored tokens goes straight to signed out', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{});
+
+      await controllerOf(c).restore();
+
+      expect(stateOf(c).status, AuthStatus.signedOut);
+    });
+
+    test('revalidates stored tokens against the backend', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kMobileMePath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+        ],
+      });
+      await seed(c);
+
+      await controllerOf(c).restore();
+
+      expect(stateOf(c).status, AuthStatus.signedIn);
+      expect(stateOf(c).username, 'ada');
+      expect(stateOf(c).isAdmin, isFalse);
+    });
+
+    test('drops a session the backend no longer accepts', () async {
+      // Covers a revoked or group-removed account: stale tokens must not
+      // survive on the device just because they parse.
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kMobileMePath: <FakeReply>[const FakeReply(401)],
+        kRefreshPath: <FakeReply>[const FakeReply(401)],
+      });
+      await seed(c);
+
+      await controllerOf(c).restore();
+
+      expect(stateOf(c).status, AuthStatus.signedOut);
+      expect(await c.read(tokenStoreProvider).read(), isNull);
+    });
+
+    test('a silent refresh keeps the user signed in', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kMobileMePath: <FakeReply>[
+          const FakeReply(401),
+          const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+        ],
+        kRefreshPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'access_token': 'a2',
+            'refresh_token': 'r2',
+          }),
+        ],
+      });
+      await seed(c);
+
+      await controllerOf(c).restore();
+
+      expect(stateOf(c).status, AuthStatus.signedIn);
+      expect(stateOf(c).username, 'ada');
+      expect((await c.read(tokenStoreProvider).read())?.accessToken, 'a2');
+    });
+  });
+
+  test('signOut clears the stored session', () async {
+    final ProviderContainer c = harness(<String, List<FakeReply>>{});
+    await seed(c);
+
+    await controllerOf(c).signOut();
+
+    expect(stateOf(c).status, AuthStatus.signedOut);
+    expect(await c.read(tokenStoreProvider).read(), isNull);
+    expect(secureStore.values, isEmpty);
+  });
+}

--- a/mobile/test/auth_interceptor_test.dart
+++ b/mobile/test/auth_interceptor_test.dart
@@ -1,0 +1,204 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickarecipe/src/core/api_client.dart';
+import 'package:pickarecipe/src/core/token_store.dart';
+
+import 'support/fakes.dart';
+
+const String _protectedPath = '/api/mobile/me';
+
+void main() {
+  late FakeSecureStore secureStore;
+  late TokenStore tokenStore;
+  late int signedOutCalls;
+
+  setUp(() {
+    secureStore = FakeSecureStore();
+    tokenStore = TokenStore(secureStore);
+    signedOutCalls = 0;
+  });
+
+  Dio build(FakeAdapter adapter) => createApiClient(
+        baseUrl: 'https://recipes.example.com',
+        tokenStore: tokenStore,
+        onSignedOut: () async => signedOutCalls++,
+        adapter: adapter,
+      );
+
+  Future<void> seedTokens({String access = 'old-access'}) => tokenStore.save(
+        AuthTokens(accessToken: access, refreshToken: 'refresh-1'),
+      );
+
+  test('attaches the bearer token to outgoing requests', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[
+        const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+      ],
+    });
+
+    await build(adapter).get<Map<String, dynamic>>(_protectedPath);
+
+    expect(
+      adapter.requests.single.headers['Authorization'],
+      'Bearer old-access',
+    );
+  });
+
+  test('sends no Authorization header when there is no session', () async {
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[
+        const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+      ],
+    });
+
+    await build(adapter).get<Map<String, dynamic>>(_protectedPath);
+
+    expect(adapter.requests.single.headers.containsKey('Authorization'), isFalse);
+  });
+
+  test('refreshes once on 401 and replays the original request', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[
+        const FakeReply(401, <String, dynamic>{'error': 'expired'}),
+        const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+      ],
+      kRefreshPath: <FakeReply>[
+        const FakeReply(200, <String, dynamic>{
+          'access_token': 'new-access',
+          'refresh_token': 'refresh-2',
+        }),
+      ],
+    });
+
+    final Response<Map<String, dynamic>> response =
+        await build(adapter).get<Map<String, dynamic>>(_protectedPath);
+
+    expect(response.statusCode, 200);
+    expect(response.data?['username'], 'ada');
+    expect(adapter.callsTo(kRefreshPath), 1);
+    expect(adapter.callsTo(_protectedPath), 2);
+    // The replay must carry the new token, not the one that just failed.
+    expect(
+      adapter.requests.last.headers['Authorization'],
+      'Bearer new-access',
+    );
+    // The rotated pair is persisted for the next launch.
+    final AuthTokens? stored = await tokenStore.read();
+    expect(stored?.accessToken, 'new-access');
+    expect(stored?.refreshToken, 'refresh-2');
+    expect(signedOutCalls, 0);
+  });
+
+  test('the refresh call itself carries no stale bearer header', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[
+        const FakeReply(401),
+        const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+      ],
+      kRefreshPath: <FakeReply>[
+        const FakeReply(200, <String, dynamic>{
+          'access_token': 'new-access',
+          'refresh_token': 'refresh-2',
+        }),
+      ],
+    });
+
+    await build(adapter).get<Map<String, dynamic>>(_protectedPath);
+
+    final RequestOptions refreshCall = adapter.requests
+        .firstWhere((RequestOptions r) => r.path == kRefreshPath);
+    expect(refreshCall.headers.containsKey('Authorization'), isFalse);
+    expect(refreshCall.data, <String, String>{'refresh_token': 'refresh-1'});
+  });
+
+  test('a rejected refresh clears the session and signals sign-out', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[const FakeReply(401)],
+      kRefreshPath: <FakeReply>[
+        const FakeReply(401, <String, dynamic>{'error': 'invalid refresh'}),
+      ],
+    });
+
+    await expectLater(
+      build(adapter).get<Map<String, dynamic>>(_protectedPath),
+      throwsA(isA<DioException>()),
+    );
+
+    expect(await tokenStore.read(), isNull);
+    expect(signedOutCalls, 1);
+    // No second attempt at the original request once the refresh is refused.
+    expect(adapter.callsTo(_protectedPath), 1);
+  });
+
+  test('a 401 is retried at most once', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      // Still 401 even with a valid new token: must not loop forever.
+      _protectedPath: <FakeReply>[const FakeReply(401)],
+      kRefreshPath: <FakeReply>[
+        const FakeReply(200, <String, dynamic>{
+          'access_token': 'new-access',
+          'refresh_token': 'refresh-2',
+        }),
+      ],
+    });
+
+    await expectLater(
+      build(adapter).get<Map<String, dynamic>>(_protectedPath),
+      throwsA(isA<DioException>()),
+    );
+
+    expect(adapter.callsTo(_protectedPath), 2);
+    expect(adapter.callsTo(kRefreshPath), 1);
+  });
+
+  test('parallel 401s spend a single refresh token', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[
+        const FakeReply(401),
+        const FakeReply(401),
+        const FakeReply(401),
+        const FakeReply(200, <String, dynamic>{'username': 'ada'}),
+      ],
+      kRefreshPath: <FakeReply>[
+        const FakeReply(200, <String, dynamic>{
+          'access_token': 'new-access',
+          'refresh_token': 'refresh-2',
+        }),
+      ],
+    });
+    final Dio dio = build(adapter);
+
+    await Future.wait<void>(<Future<void>>[
+      dio.get<Map<String, dynamic>>(_protectedPath),
+      dio.get<Map<String, dynamic>>(_protectedPath),
+      dio.get<Map<String, dynamic>>(_protectedPath),
+    ]);
+
+    // Three concurrent failures, one refresh: rotating the token three times
+    // would invalidate the pair the other two are about to use.
+    expect(adapter.callsTo(kRefreshPath), 1);
+  });
+
+  test('non-401 failures are passed through untouched', () async {
+    await seedTokens();
+    final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+      _protectedPath: <FakeReply>[const FakeReply(500)],
+    });
+
+    await expectLater(
+      build(adapter).get<Map<String, dynamic>>(_protectedPath),
+      throwsA(isA<DioException>()),
+    );
+
+    expect(adapter.callsTo(kRefreshPath), 0);
+    expect(signedOutCalls, 0);
+    // A server error must not cost the user their session.
+    expect(await tokenStore.read(), isNotNull);
+  });
+}

--- a/mobile/test/support/fakes.dart
+++ b/mobile/test/support/fakes.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:pickarecipe/src/core/token_store.dart';
+
+/// In-memory stand-in for the keystore.
+class FakeSecureStore implements SecureKeyValueStore {
+  final Map<String, String> values = <String, String>{};
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String value) async => values[key] = value;
+
+  @override
+  Future<void> delete(String key) async => values.remove(key);
+}
+
+/// A single canned HTTP reply.
+class FakeReply {
+  const FakeReply(this.statusCode, [this.body = const <String, dynamic>{}]);
+
+  final int statusCode;
+  final Map<String, dynamic> body;
+}
+
+/// Dio adapter that replays queued replies per path and records every request,
+/// so tests can assert on headers and call ordering without a live server.
+class FakeAdapter implements HttpClientAdapter {
+  FakeAdapter(this._queues);
+
+  final Map<String, List<FakeReply>> _queues;
+  final List<RequestOptions> requests = <RequestOptions>[];
+
+  int callsTo(String path) =>
+      requests.where((RequestOptions r) => r.path == path).length;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+
+    final List<FakeReply>? queue = _queues[options.path];
+    if (queue == null || queue.isEmpty) {
+      throw StateError('No fake reply queued for ${options.path}');
+    }
+    // The last reply is reused once exhausted, so a test only has to queue the
+    // transitions it cares about.
+    final FakeReply reply =
+        queue.length == 1 ? queue.first : queue.removeAt(0);
+
+    return ResponseBody.fromString(
+      jsonEncode(reply.body),
+      reply.statusCode,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/mobile/test/token_store_test.dart
+++ b/mobile/test/token_store_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickarecipe/src/core/token_store.dart';
+
+import 'support/fakes.dart';
+
+void main() {
+  late FakeSecureStore store;
+  late TokenStore tokens;
+
+  setUp(() {
+    store = FakeSecureStore();
+    tokens = TokenStore(store);
+  });
+
+  test('round-trips a token pair', () async {
+    await tokens.save(
+      const AuthTokens(accessToken: 'aaa', refreshToken: 'rrr'),
+    );
+
+    final AuthTokens? read = await tokens.read();
+    expect(read?.accessToken, 'aaa');
+    expect(read?.refreshToken, 'rrr');
+  });
+
+  test('reads null when nothing is stored', () async {
+    expect(await tokens.read(), isNull);
+  });
+
+  test('a partial pair reads as no session', () async {
+    // An access token with no refresh token cannot be renewed, so treating it
+    // as a session would strand the user at the first 401.
+    store.values['auth.access_token'] = 'aaa';
+
+    expect(await tokens.read(), isNull);
+  });
+
+  test('clear removes both halves', () async {
+    await tokens.save(
+      const AuthTokens(accessToken: 'aaa', refreshToken: 'rrr'),
+    );
+
+    await tokens.clear();
+
+    expect(store.values, isEmpty);
+    expect(await tokens.read(), isNull);
+  });
+
+  test('tokens are not stored under guessable plaintext-ish keys', () async {
+    await tokens.save(
+      const AuthTokens(accessToken: 'aaa', refreshToken: 'rrr'),
+    );
+
+    // Namespaced keys keep them from colliding with other secure-storage users.
+    expect(store.values.keys, everyElement(startsWith('auth.')));
+  });
+}


### PR DESCRIPTION
Wires the Flutter app up to the `/api/mobile/*` endpoints from #15. The login and home screens were literal `Text('… placeholder')` widgets before this; no Dart code called the backend.

## How sign-in works

1. App requests `GET /api/mobile/auth/login-url?redirect=par://auth/callback`; the server mints a single-use nonce and uses it as the OAuth `state`.
2. The returned URL opens in the **system browser**, not a webview — an existing Authentik session cookie is reused, and credential entry never happens inside app code.
3. Authentik redirects to the server's own `/auth/callback`, which recognises the nonce, exchanges the code with its confidential client credentials, and checks group membership.
4. Server redirects to `par://auth/callback#access_token=…&refresh_token=…`. Tokens ride in the **fragment**, which browsers never send upstream, so they stay out of access logs and `Referer` headers.
5. App stores the pair and confirms it with `GET /api/mobile/me` before showing a signed-in UI.

No Authentik configuration change is needed: the registered redirect URI is still the server's own callback, and the `par://` scheme is only ever seen on-device.

## Token handling

- Stored via `flutter_secure_storage` — on Android that is AES-GCM under an RSA-OAEP-wrapped keystore key. Never shared preferences, never logged.
- `AuthInterceptor` attaches the access token and, on a 401, refreshes once and replays the original request, so the 15-minute expiry is invisible.
- Concurrent 401s share a single in-flight refresh; rotating the refresh token three times in parallel would invalidate the pair the other calls are about to use.
- A refused refresh clears the pair and drops to the login screen. A 500 does *not* cost the user their session.
- Restored tokens are always revalidated against `/api/mobile/me`, so a revoked or de-grouped account does not linger on the device just because its tokens still parse.

## Also here

- **The Android app did not build before this PR**, on any branch. `isCoreLibraryDesugaringEnabled = true` was set with no `coreLibraryDesugaring` artifact, so AGP failed configuring `:app:l8DexDesugarLibDebug`. Fixed in its own commit (604fdd0).
- Android 11+ package-visibility query, without which `url_launcher` cannot see a browser to hand the sign-in URL to.
- `mobile/README.md` replaced — it was still the stock `flutter create` text.

## Known limitation

Custom schemes are not exclusive on Android: another installed app can also register `par://` and receive the redirect. Closing that gap means verified App Links (an `https://` callback plus a hosted `assetlinks.json`), which is a server-side change too. Called out in `mobile/README.md` as follow-up rather than silently accepted.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 39 passing (3 pre-existing + 36 new)
- [x] `flutter build apk --debug` succeeds
- [x] `par://auth` intent filter and `https` query verified in the built APK via `aapt2`
- [ ] Manual: sign in on a device against `recipes.pickel.me`, confirm the browser round trip and that the session survives a restart

Made with [Cursor](https://cursor.com)