### PR TITLE
ci: gate pull requests on server, web, and Android checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+# Pre-merge checks.
+#
+# deploy.yml only fires once main has already moved, so before this workflow
+# nothing verified a pull request: a red test, a type error in the SPA, or a
+# broken Android build config could all reach main unnoticed.
+#
+# Every job runs on every pull request regardless of which paths changed. A
+# paths filter would report "skipped" rather than "success", which blocks a
+# required status check instead of satisfying it.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  server:
+    name: Server tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Matches the runtime image in Dockerfile.
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements*.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        # Each test module puts the repo root and ui/ on sys.path itself, so no
+        # PYTHONPATH is needed here.
+        run: python -m pytest tests/ -q
+
+  frontend:
+    name: Web UI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # Matches the build stage in Dockerfile.
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: ui/frontend/package-lock.json
+
+      - name: Install dependencies
+        # ci, not install: honours the lockfile exactly, as the image build does.
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        # Runs tsc -b before vite build, so this is the type check too. The
+        # image build does the same, meaning a type error here would otherwise
+        # only surface as a failed deploy after merge.
+        run: npm run build
+
+  mobile:
+    name: Android app
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          # Matches jvmTarget in android/app/build.gradle.kts.
+          java-version: '17'
+
+      - name: Set up Flutter
+        # Third-party action, pinned to a commit rather than a movable tag.
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: 3.44.8
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test
+
+      - name: Build debug APK
+        # Neither analyze nor test touches Gradle, which is exactly how a
+        # broken Android build config survived from the scaffold commit until
+        # someone tried to build an APK by hand.
+        run: flutter build apk --debug --dart-define=FLAVOR=dev

--- a/llm_resilience.py
+++ b/llm_resilience.py
@@ -199,5 +199,6 @@ def call_with_model_fallback(provider, configured_model, call, *, persist=True):
     raise ModelUnavailableError(
         f"The configured {provider} model '{configured_model}' and all fallbacks "
         f"are unavailable or persistently overloaded: {candidates}. "
+        f"Pick a currently available {provider} model in Settings. "
         f"Last error: {last_error}"
     )

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -60,6 +60,13 @@ android {
     }
 }
 
+dependencies {
+    // Required whenever isCoreLibraryDesugaringEnabled is true; without it AGP
+    // fails to configure :app:l8DexDesugarLibDebug. Version pinned, resolved
+    // from google() as declared in settings.gradle.kts.
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+}
+
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Development and test dependencies.
+#
+# Includes the runtime set so a single install gets you a working checkout:
+#   pip install -r requirements-dev.txt
+#   pytest tests/
+-r requirements.txt
+
+# Pinned to a major line: test-runner majors change collection behaviour.
+pytest~=9.1


### PR DESCRIPTION
`deploy.yml` triggers only on push to `main`, so **nothing currently verifies a pull request**. Two consequences already visible in this repo:

- `test_llm_resilience.py` has been failing on `main` with nobody notified.
- The Android app has not built since the scaffold commit — `flutter analyze` and `flutter test` never invoke Gradle, so the broken config was invisible until someone tried to produce an APK by hand.

## What runs

| Job | Mirrors | Steps |
| --- | --- | --- |
| Server tests | Dockerfile's `python:3.11-slim` | `pytest tests/` |
| Web UI | Dockerfile's `node:22-alpine` stage | `npm ci`, `oxlint`, `tsc -b && vite build` |
| Android app | a developer's local loop | `flutter analyze`, `flutter test`, `flutter build apk --debug` |

The frontend job matters more than it looks: `npm run build` runs `tsc -b` first, and the image build does the same. Without this, a type error doesn't fail the PR — it fails the **deploy**, after merge.

The APK build is included on purpose, for the reason above.

## Notes on the shape of it

- Jobs run on every PR rather than behind a `paths` filter. A filtered job reports `skipped`, which does not satisfy a required status check and would block merges instead of gating them.
- `subosito/flutter-action` is third-party, so it's pinned to a commit SHA rather than the movable `v2` tag. The `actions/*` steps keep the tag style already used in `deploy.yml`.
- Versions track production deliberately: Python 3.11 and Node 22 from the Dockerfile, JDK 17 from `jvmTarget` in `build.gradle.kts`.
- `requirements-dev.txt` gives `pytest` a declared home — the suite needed it but nothing listed it, so a fresh checkout couldn't run the tests.

## The one test fix

`test_all_models_unavailable_raises_actionable_error` asserts the error tells the user where to go and fix it. The message listed the models tried and the last error but no next step, so the test failed. `/settings` does expose `openai_model` and `gemini_model`, so naming Settings is accurate advice. Fixed the message rather than weakening the assertion.

## Test plan

Rehearsed locally before pushing, since a CI workflow that is red on arrival is worse than none:

- [x] `pip install -r requirements-dev.txt` into a clean venv, then `pytest tests/` — **90 passed** (all 11 modules, including `test_video_downloader.py`, which cannot run without `yt_dlp` present)
- [x] `npm ci && npm run lint && npm run build` — both exit 0 (15 pre-existing warnings, 0 errors, so lint will not block)
- [x] `flutter analyze` clean, `flutter test` 39 passing, `flutter build apk --debug` succeeds
- [x] Workflow YAML parses; third-party action pinned by SHA

## Merge order

Worth merging before #18. Workflows come from the PR branch, so #18 needs a rebase onto a `main` that has `ci.yml` before these checks will run against it.

Made with [Cursor](https://cursor.com)

---

## Update: the workflow proved itself on its own PR

First run, before any Android fix was on this branch:

- Server tests **pass** (27s), Web UI **pass** (34s)
- Android app **fail** (4m1s) — `flutter analyze` and `flutter test` both passed; only `flutter build apk` failed, with `coreLibraryDesugaring configuration contains no dependencies`

That is the blind spot described above, reproduced on `main`'s code by the new job on its very first run.

The one-line Gradle fix is now cherry-picked into this PR (`4532378`) so it stands alone, and all three jobs are green: Server 32s, Web 24s, Android 5m36s.

Because the same commit is also on #18, git will drop it as already-applied when #18 rebases — no conflict to resolve.
