### PR TITLE
ci: attach a signed Android APK to published releases

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,155 @@
+# Builds the Android APK and attaches it to a GitHub release.
+#
+# Releases are still created by hand, as they always have been; this only
+# attaches the APK once one is published. Use the manual trigger to attach an
+# APK to a release that already exists.
+#
+# Required repository secrets — mobile/android/key.properties.example has the
+# keytool command and setup steps:
+#   ANDROID_KEYSTORE_BASE64    base64 of the upload keystore (.jks)
+#   ANDROID_KEYSTORE_PASSWORD  keystore password
+#   ANDROID_KEY_PASSWORD       key password
+#   ANDROID_KEY_ALIAS          key alias (e.g. upload)
+#
+# The signing identity cannot be changed once users have installed a build:
+# Android refuses an update signed with a different key. Treat the keystore as
+# unrecoverable if lost.
+name: Release APK
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to attach an APK to (e.g. v1.6.0)'
+        required: true
+
+concurrency:
+  group: release-apk-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # required to upload a release asset
+
+jobs:
+  apk:
+    name: Build and attach APK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release tag
+        id: release
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No release tag to work with"
+            exit 1
+          fi
+          # Android versionName has no leading 'v'.
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check signing secrets are present
+        env:
+          KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [[ -z "$KEYSTORE" ]]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set. See" \
+                 "mobile/android/key.properties.example. Publishing a" \
+                 "debug-signed APK would lock users out of future updates."
+            exit 1
+          fi
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        # Third-party action, pinned to a commit rather than a movable tag.
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: 3.44.8
+          channel: stable
+          cache: true
+
+      - name: Restore signing keystore
+        working-directory: mobile/android
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          # No shell tracing in this step: it would echo the passwords.
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > app/upload.jks
+          # storeFile is resolved relative to android/app.
+          {
+            printf 'storeFile=upload.jks\n'
+            printf 'storePassword=%s\n' "$STORE_PASSWORD"
+            printf 'keyPassword=%s\n' "$KEY_PASSWORD"
+            printf 'keyAlias=%s\n' "$KEY_ALIAS"
+          } > key.properties
+          echo "Keystore restored ($(stat -c%s app/upload.jks) bytes)"
+
+      - name: Install dependencies
+        working-directory: mobile
+        run: flutter pub get
+
+      - name: Build release APK
+        working-directory: mobile
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          # build-name comes from the tag so the APK reports the same version
+          # as the release. build-number must only ever increase, which
+          # run_number guarantees; the tag cannot, since Android needs an int.
+          #
+          # Deliberately not obfuscated. Nothing sensitive is compiled in — the
+          # OIDC client secret stays server-side by design, and the API host and
+          # deep-link scheme are already public in the manifest — so the only
+          # effects would be unreadable crash traces and a published artifact
+          # that differs from the one tested by hand.
+          flutter build apk --release \
+            --dart-define=FLAVOR=prod \
+            --build-name="$VERSION" \
+            --build-number="${{ github.run_number }}"
+
+      - name: Report signing certificate
+        working-directory: mobile
+        run: |
+          # Printed so a key change between releases is noticeable: a differing
+          # fingerprint means installed users cannot update in place.
+          APKSIGNER=$(find "$ANDROID_HOME"/build-tools -name apksigner | sort -V | tail -1)
+          "$APKSIGNER" verify --print-certs \
+            build/app/outputs/flutter-apk/app-release.apk \
+            | grep -iE 'certificate DN|SHA-256' || true
+
+      - name: Name the asset after the release
+        id: asset
+        working-directory: mobile
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          NAME="pick-a-recipe-$TAG.apk"
+          cp build/app/outputs/flutter-apk/app-release.apk "$NAME"
+          echo "path=mobile/$NAME" >> "$GITHUB_OUTPUT"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          ls -lh "$NAME"
+
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ASSET: ${{ steps.asset.outputs.path }}
+        # clobber so re-running the job replaces the asset instead of failing.
+        run: gh release upload "$TAG" "$ASSET" --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Remove signing material
+        if: always()
+        working-directory: mobile/android
+        run: rm -f app/upload.jks key.properties

--- a/mobile/android/key.properties.example
+++ b/mobile/android/key.properties.example
@@ -1,11 +1,35 @@
-# Copy to android/key.properties (gitignored) to enable release signing.
-# Generate a keystore first (keep the .jks OUT of git):
+# Release signing.
 #
-#   keytool -genkey -v -keystore ~/pick-a-recipe-upload.jks \
-#     -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+# The signing key CANNOT be changed once anyone has installed a build: Android
+# refuses an update signed with a different key, so users would have to
+# uninstall and lose their data. Losing the keystore has the same effect.
+# Generate it once, back it up somewhere durable.
 #
-# Then fill in the values below. storeFile may be absolute or relative to
-# android/app/.
+#   keytool -genkeypair -v -keystore ~/pick-a-recipe-upload.jks \
+#     -keyalg RSA -keysize 4096 -validity 10000 -alias upload
+#
+# Keep the .jks OUT of git.
+#
+# ── Local builds ─────────────────────────────────────────────────────────────
+# Copy this file to android/key.properties (gitignored) and fill it in.
+# storeFile may be absolute, or relative to android/app/.
+#
+# Without key.properties, a release build falls back to the debug key. That is
+# fine for testing on your own device, but never publish the result.
+#
+# ── CI releases ──────────────────────────────────────────────────────────────
+# .github/workflows/release-apk.yml writes this file itself from repository
+# secrets, so nothing here needs committing. Add these under
+# Settings -> Secrets and variables -> Actions:
+#
+#   ANDROID_KEYSTORE_BASE64     base64 -i ~/pick-a-recipe-upload.jks | pbcopy
+#   ANDROID_KEYSTORE_PASSWORD   the -storepass you chose
+#   ANDROID_KEY_PASSWORD        the -keypass you chose (often the same)
+#   ANDROID_KEY_ALIAS           upload
+#
+# That workflow fails early if the keystore secret is missing rather than
+# silently publishing a debug-signed APK. It also prints the certificate's
+# SHA-256 fingerprint on every run: it must stay identical across releases.
 storePassword=CHANGE_ME
 keyPassword=CHANGE_ME
 keyAlias=upload


### PR DESCRIPTION
Releases carried no downloadable app, so trying the Android client meant checking out the repo and building it. Publishing a release now builds a release APK and attaches it as `pick-a-recipe-<tag>.apk`.

A release build is **48MB** against the 151MB debug build, so it's the right artifact to hand out.

## The signing decision

The signing identity can't be changed after the fact — Android refuses an update signed with a different key, and installers would have to uninstall and lose their data. So this requires a real upload keystore and **fails outright when the keystore secret is missing**, rather than inheriting the local fallback to the debug key. That fallback is fine for testing on your own device but would be a trap in a published release.

Every run prints the certificate's SHA-256 fingerprint, so an accidental key change is visible in the log instead of surfacing later as failed updates.

## Setup required before the first release

Four repository secrets, with the `keytool` command and steps in `mobile/android/key.properties.example`:

| Secret | Value |
| --- | --- |
| `ANDROID_KEYSTORE_BASE64` | base64 of the upload `.jks` |
| `ANDROID_KEYSTORE_PASSWORD` | store password |
| `ANDROID_KEY_PASSWORD` | key password |
| `ANDROID_KEY_ALIAS` | `upload` |

## Versioning

`mobile/pubspec.yaml` says `1.0.0+1` while the tags are at `v1.5.0`, so an APK would have misreported its version. `versionName` now comes from the release tag and `versionCode` from the run number, which satisfies Android's requirement for an ever-increasing integer that a semver tag can't provide.

## Trigger

Fires when a release is *published*, matching the existing by-hand release flow: create the release as usual and the APK gets attached. A manual trigger takes a tag, for attaching an APK to a release that already exists or re-running a failed upload.

## Verification

Rehearsed locally end to end with a throwaway 4096-bit keystore, exercising the same restore-and-build path the workflow uses:

- APK signed with the supplied key, `certificate DN: CN=Pick-a-Recipe Rehearsal` — confirming it does **not** silently fall through to the debug key
- `--build-name=1.6.0 --build-number=42` produced `versionName='1.6.0' versionCode='42'`
- Release build succeeds; keystore path resolves relative to `android/app` as the Gradle config expects

Untested until secrets exist: the `gh release upload` step and tag resolution.

## Note on obfuscation

I tried `--obfuscate` and backed it out. Nothing sensitive is compiled into the app — the OIDC client secret stays server-side by design, and the API host and deep-link scheme are already public in the manifest — so it would only have bought unreadable crash traces and a published artifact differing from the one tested by hand. Flutter also warned that the ELF retains unobfuscated DWARF info, with no flag exposed at this layer to fix it. Worth revisiting alongside crash reporting that can consume symbol files.

Made with [Cursor](https://cursor.com)