### PR TITLE
fix(mobile): return identity-provider errors to the app, not the web login

### DIFF
--- a/tests/test_mobile_auth.py
+++ b/tests/test_mobile_auth.py
@@ -193,6 +193,41 @@ class TestMobileCallback(MobileAuthTestCase):
         self.assertIsNotNone(self.mobile_auth.decode_token(claims['access_token'][0], expected_type='access'))
         self.assertIsNotNone(self.mobile_auth.decode_token(claims['refresh_token'][0], expected_type='refresh'))
 
+    def test_idp_error_travels_back_over_the_deep_link(self):
+        """An error during app sign-in must not land on the web login page.
+
+        Redirecting to /login would leave the user stranded in a browser while
+        the app waits indefinitely, having been told nothing.
+        """
+        client = self._client()
+        nonce = self._save_nonce()
+        resp = client.get(f'/auth/callback?error=access_denied&state={nonce}')
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp.headers['Location'],
+            'par://auth/callback#error=access_denied',
+        )
+
+    def test_unrecognised_idp_error_is_not_reflected(self):
+        """Only RFC 6749 codes pass through; anything else is reported generically."""
+        client = self._client()
+        nonce = self._save_nonce()
+        resp = client.get(
+            f'/auth/callback?error=%3Cscript%3Ealert(1)%3C/script%3E&state={nonce}'
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp.headers['Location'],
+            'par://auth/callback#error=server_error',
+        )
+
+    def test_web_flow_errors_still_flash_and_redirect(self):
+        """The browser flow keeps its existing behaviour when there is no nonce."""
+        client = self._client()
+        resp = client.get('/auth/callback?error=access_denied&state=not-a-nonce')
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('/login', resp.headers['Location'])
+
     def test_nonce_is_single_use(self):
         client = self._client()
         nonce = self._save_nonce()

--- a/ui/app.py
+++ b/ui/app.py
@@ -573,6 +573,23 @@ def _authentik_token_endpoints() -> tuple[str, str]:
         return f'{AUTHENTIK_ISSUER_URL}/token/', f'{AUTHENTIK_ISSUER_URL}/userinfo/'
 
 
+# The set RFC 6749 §4.1.2.1 defines. Anything outside it is reported
+# generically rather than reflected, so a provider cannot put text of its
+# choosing into a redirect aimed at the app.
+_OAUTH_ERROR_CODES = frozenset({
+    'invalid_request', 'unauthorized_client', 'access_denied',
+    'unsupported_response_type', 'invalid_scope', 'server_error',
+    'temporarily_unavailable',
+})
+
+
+def _mobile_idp_error(nonce_row: dict, idp_error: str):
+    """Hand an identity-provider error back to the app over its deep link."""
+    code = idp_error if idp_error in _OAUTH_ERROR_CODES else 'server_error'
+    print(f'[MobileAuth] identity provider returned error={code}')
+    return redirect(f'{nonce_row["redirect_uri"]}#{urlencode({"error": code})}')
+
+
 def _mobile_oidc_callback(code: str | None, nonce_row: dict):
     """Finish sign-in for the Android app and hand tokens back via deep link.
 
@@ -645,23 +662,30 @@ def auth_callback():
     if oauth is None:
         return redirect(url_for('login'))
 
-    if 'error' in request.args:
-        reason = request.args.get('error_description') or request.args.get('error')
-        flash(f'Sign-in failed: {reason}', 'error')
-        return redirect(url_for('login'))
+    idp_error = request.args.get('error')
 
-    # A state we issued as a mobile nonce belongs to the app flow. Recognising a
-    # spent one lets us reject a replay outright instead of falling through to
-    # the browser flow, which would only fail with a confusing session error.
+    # Which flow this callback belongs to has to be settled before the error is
+    # handled. A state we issued as a mobile nonce belongs to the app, and its
+    # errors have to travel back over the deep link; flashing them would strand
+    # the user in a browser on the web login page with the app none the wiser.
+    # Recognising a spent nonce also lets us reject a replay outright instead of
+    # falling through to the browser flow and failing with a session error.
     state = request.args.get('state') or ''
     if state:
         nonce_row = consume_mobile_nonce(state)
         if nonce_row is not None:
+            if idp_error:
+                return _mobile_idp_error(nonce_row, idp_error)
             return _mobile_oidc_callback(request.args.get('code'), nonce_row)
         if mobile_nonce_exists(state):
             print('[MobileAuth] rejected replayed or expired sign-in state')
             return jsonify({'error': 'This sign-in link has already been used or '
                                      'has expired. Please sign in again.'}), 400
+
+    if idp_error:
+        reason = request.args.get('error_description') or idp_error
+        flash(f'Sign-in failed: {reason}', 'error')
+        return redirect(url_for('login'))
 
     try:
         token = oauth.authentik.authorize_access_token()


### PR DESCRIPTION
Found while diagnosing a failed sign-in attempt on a device.

`/auth/callback` handled the `error` parameter *before* working out which flow the callback belonged to:

```python
if 'error' in request.args:      # ran first, for every flow
    flash(...); return redirect(url_for('login'))

state = request.args.get('state')  # mobile nonce check came after
```

So when Authentik returns an error during **app** sign-in, the server flashed a message and redirected to the **web** login page. The user ends up stranded in a browser looking at a page they didn't ask for, while the app sits on its login screen waiting for a deep link that never arrives — told nothing at all.

## Change

Settle which flow the callback belongs to first, then handle the error. A `state` matching a mobile nonce now routes the error back over the deep link as `par://auth/callback#error=<code>`, which the app already knows how to display.

Only the seven codes RFC 6749 §4.1.2.1 defines pass through. Anything else becomes `server_error` rather than being reflected, so a provider can't put text of its choosing into a redirect aimed at the app. The browser flow keeps its existing flash-and-redirect behaviour unchanged.

## Tests

Three added, 93 pass in total:

- an `access_denied` with a mobile nonce redirects to the deep link, not `/login`
- an unrecognised code (a `<script>` payload) collapses to `server_error`
- the web flow still flashes and redirects when there is no nonce

## Not the cause of the failure I was chasing

Worth stating plainly: this is a latent bug, not the reason sign-in failed on the device. That turned out to be the Authentik instance being down — `/-/health/live/` returning 503 persistently, and its error page reading "authentik Server Error". This path would only have compounded it.

## Noted for follow-up

`JWT_SECRET_KEY` has no minimum length check, so a short secret silently yields weak HMAC signing (PyJWT warns about it in the test run). Left out of this PR to keep it focused; it belongs with the auth work coming next.

Made with [Cursor](https://cursor.com)