### PR TITLE
feat(auth): local username and password accounts, replacing AUTH_MODE=none

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,14 +13,14 @@ FLASK_DEBUG=false
 # Job queue — parallel extractions (1–16, default 3)
 MAX_CONCURRENT_JOBS=3
 
-# Authentication mode: 'authentik' (default) or 'none'.
-# Use 'none' to run without any identity provider — every request becomes a
-# single local admin. Only do this on a trusted network: an unauthenticated
-# instance exposes the API keys stored in Settings to anyone who can reach it.
-# AUTH_MODE=none
-# AUTH_LOCAL_USERNAME=local
+# Authentication mode: 'local' (default) or 'authentik'.
+# 'local' needs no identity provider: the first visit lands on /setup to create
+# the admin account, and that page closes for good once an account exists.
+# AUTH_MODE=local
+# Prefills the username field on the setup page; nothing more.
+# AUTH_LOCAL_USERNAME=admin
 
-# Authentik SSO (required for login unless AUTH_MODE=none)
+# Authentik SSO (required when AUTH_MODE=authentik)
 AUTHENTIK_ISSUER_URL=https://auth.pickel.me/application/o/pick-a-recipe
 AUTHENTIK_CLIENT_ID=
 AUTHENTIK_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ docker run -d \
   --name pick-a-recipe \
   -p 5006:5006 \
   -e FLASK_SECRET_KEY="your-secure-secret-key" \
-  -e AUTH_MODE=none \
   -v pick-a-recipe-data:/app/data \
   pickeld/pick-a-recipe:latest
 ```
 
-Access the web UI at `http://localhost:5006`
+Open `http://localhost:5006` and pick a username and password. That first visit
+is the only time the setup page is available; once an account exists it closes
+for good.
 
-`AUTH_MODE=none` runs the app with no sign-in, as a single local admin — the
-quickest way to get started on a home network. To require sign-in instead, see
-[Authentication](#authentication).
+No identity provider is needed. If you would rather sign in through Authentik,
+see [Authentication](#authentication).
 
 **Option 2: Using Docker Compose**
 
@@ -80,7 +80,6 @@ services:
       - "5006:5006"
     environment:
       - FLASK_SECRET_KEY=your-secure-secret-key
-      - AUTH_MODE=none
     volumes:
       - pick-a-recipe-data:/app/data
 
@@ -94,7 +93,7 @@ Then run:
 docker-compose up -d
 ```
 
-Access the web UI at `http://localhost:5006`
+Open `http://localhost:5006` and create your account.
 
 ### Manual Installation
 
@@ -122,12 +121,10 @@ Access the web UI at `http://localhost:5006`
 
 4. Run the application:
    ```bash
-   AUTH_MODE=none python ui/app.py
+   python ui/app.py
    ```
-   `AUTH_MODE=none` skips sign-in for local development. Omit it to require
-   Authentik single sign-on — see [Authentication](#authentication).
 
-5. Access the web UI at `http://localhost:5006`
+5. Open `http://localhost:5006` and create your account on the setup page.
 
 ## Configuration
 
@@ -135,36 +132,61 @@ All configuration is managed through the web UI settings page (`/settings`).
 
 ### Authentication
 
-Pick-a-Recipe has two authentication modes, selected with `AUTH_MODE`:
+Sign-in is always required. Settings holds your LLM, Mealie and Tandoor API
+keys, so an instance anyone can reach is an instance that hands those out.
+
+Two modes, selected with `AUTH_MODE`:
 
 | `AUTH_MODE` | Behaviour |
 |-------------|-----------|
-| `authentik` (default) | Sign-in is required, via Authentik single sign-on (OIDC). |
-| `none` | No sign-in. Every request runs as one local admin. |
+| `local` (default) | Username and password accounts stored by this app. No identity provider needed. |
+| `authentik` | Authentik single sign-on (OIDC). Accounts and groups come from Authentik. |
 
-**`AUTH_MODE=none` — no identity provider**
+**`local` — accounts stored by this app (default)**
 
-Set `AUTH_MODE=none` and the app is immediately usable with no sign-in step:
+Start the app and open it in a browser. With no account yet, every page redirects
+to `/setup`, where you choose a username and password:
 
 ```bash
 docker run -d --name pick-a-recipe -p 5006:5006 \
-  -e AUTH_MODE=none \
   -v pick-a-recipe-data:/app/data \
   pickeld/pick-a-recipe:latest
 ```
 
-> ⚠️ There is no access control at all in this mode. Anyone who can reach the
-> port has full access, including the LLM, Mealie and Tandoor API keys stored in
-> Settings. Only use it on a trusted network — never expose it to the internet.
+The setup page is reachable only while the instance has no account, and closes
+permanently once one exists — so nobody can use it to add a second admin or
+reset your password. If your instance is already reachable from the internet
+when you first start it, create the account promptly: until you do, whoever
+loads that page first gets it. `AUTH_LOCAL_USERNAME` prefills the username
+field, nothing more.
 
-The local account is named `local`; override it with `AUTH_LOCAL_USERNAME`.
+Passwords must be at least 10 characters, with no composition rules: length is
+what makes a password hard to guess, while forced symbols mostly produce
+predictable substitutions. They are stored as Argon2id hashes with a per-account
+salt, and rehashed automatically if the cost parameters are ever raised.
 
-**`AUTH_MODE=authentik` — single sign-on (default)**
+Repeated failures are slowed progressively rather than locking the account,
+which would let anyone who knows your username lock you out at will. Wrong
+password and no-such-user return the same message and take comparable time, so
+the login form cannot be used to discover which accounts exist.
+
+**Upgrading from `AUTH_MODE=none`**
+
+That mode is gone; authentication can no longer be switched off. An instance
+still setting it boots with a warning and is treated as `local`, landing on the
+setup page. Ownership of recipes and history is recorded against the username
+that mode used, so the setup page offers that name and reuses the account rather
+than creating a second one — accept it, pick a password, and your history
+carries over. Typing a different name starts with an empty history. Update your
+configuration to `AUTH_MODE=local`, or drop the variable entirely.
+
+**`authentik` — single sign-on**
 
 Requires an [Authentik](https://goauthentik.io/) instance. Create an OAuth2/OIDC
 provider for the app and set:
 
 ```bash
+AUTH_MODE=authentik
 AUTHENTIK_ISSUER_URL=https://auth.example.com/application/o/pick-a-recipe
 AUTHENTIK_CLIENT_ID=...
 AUTHENTIK_CLIENT_SECRET=...
@@ -179,9 +201,12 @@ Behind a reverse proxy, set `PUBLIC_URL` (or `AUTHENTIK_REDIRECT_URI`) so the
 OIDC callback URL matches what you registered in Authentik, and set
 `SESSION_COOKIE_SECURE=true` when serving over HTTPS.
 
-If neither `AUTH_MODE=none` nor Authentik credentials are configured, nobody can
-sign in and the login page will say so — this is the default, and it fails closed
-on purpose.
+Password sign-in is refused outright in this mode, so an account that happens to
+carry a password cannot be used to go around single sign-on.
+
+With `AUTH_MODE=authentik` set but no client credentials configured, nobody can
+sign in and the login page says so. It fails closed on purpose; drop `AUTH_MODE`
+to fall back to local accounts.
 
 **Android app sign-in**
 
@@ -328,10 +353,10 @@ docker pull pickeld/pick-a-recipe:v1.0.0
 | `FLASK_SECRET_KEY` | Secret key for session cookies | Auto-generated |
 | `FLASK_DEBUG` | Enable debug mode | `false` |
 | `MAX_CONCURRENT_JOBS` | Parallel extraction workers (1–16) | `3` (or Settings value) |
-| `AUTH_MODE` | `authentik` for SSO, or `none` to disable sign-in ([details](#authentication)) | `authentik` |
-| `AUTH_LOCAL_USERNAME` | Account name used when `AUTH_MODE=none` | `local` |
+| `AUTH_MODE` | `local` for accounts stored by this app, or `authentik` for SSO ([details](#authentication)) | `local` |
+| `AUTH_LOCAL_USERNAME` | Prefills the username field on the setup page | `admin` |
 | `AUTHENTIK_ISSUER_URL` | Authentik OIDC issuer URL | `https://auth.pickel.me/application/o/pick-a-recipe` |
-| `AUTHENTIK_CLIENT_ID` | Authentik OAuth2 client ID (required unless `AUTH_MODE=none`) | — |
+| `AUTHENTIK_CLIENT_ID` | Authentik OAuth2 client ID (required when `AUTH_MODE=authentik`) | — |
 | `AUTHENTIK_CLIENT_SECRET` | Authentik OAuth2 client secret | — |
 | `AUTHENTIK_USER_GROUP` | Authentik group required for access | `pick-a-recipe-users` |
 | `AUTHENTIK_ADMIN_GROUP` | Authentik group granting admin rights | `admins` |
@@ -355,8 +380,7 @@ services:
       - HOST=0.0.0.0
       - PORT=5006
       - FLASK_SECRET_KEY=your-secure-secret-key
-      # No sign-in; see the Authentication section before exposing this
-      - AUTH_MODE=none
+      # Local accounts by default; create yours on first visit at /setup
     volumes:
       - pick-a-recipe-data:/app/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,11 @@ services:
       - HOST=0.0.0.0
       - PORT=5006
       - FLASK_SECRET_KEY=change-me-to-a-random-secret-key
-      # No identity provider in this quickstart, so authentication is off and
-      # everything runs as a single local admin. Keep this on a trusted network:
-      # anyone who can reach the port can read the API keys stored in Settings.
-      # To require sign-in instead, drop AUTH_MODE and set AUTHENTIK_CLIENT_ID /
-      # AUTHENTIK_CLIENT_SECRET (see README → Authentication).
-      - AUTH_MODE=none
+      # Authentication defaults to local accounts stored by this app. The first
+      # visit lands on /setup to create the admin account; that page closes for
+      # good once an account exists, so create it before exposing the port.
+      # For Authentik single sign-on instead, set AUTH_MODE=authentik plus
+      # AUTHENTIK_CLIENT_ID / AUTHENTIK_CLIENT_SECRET (README → Authentication).
     volumes:
       - pick-a-recipe:/app/data
       - pick-a-recipe:/tmp

--- a/portainer/stack.env
+++ b/portainer/stack.env
@@ -10,11 +10,11 @@ FLASK_SECRET_KEY=change-me-to-a-random-secret-key
 # Job queue — parallel extractions (1–16, default 3)
 MAX_CONCURRENT_JOBS=3
 
-# Authentication mode: 'authentik' (default) or 'none' to disable sign-in
-# entirely. Leave as authentik for anything reachable from the internet.
+# Authentication mode: 'local' (default) for accounts stored by this app, or
+# 'authentik' for single sign-on. This deployment uses Authentik.
 AUTH_MODE=authentik
 
-# Authentik SSO (required for login unless AUTH_MODE=none)
+# Authentik SSO (required when AUTH_MODE=authentik)
 AUTHENTIK_ISSUER_URL=https://auth.pickel.me/application/o/pick-a-recipe
 AUTHENTIK_CLIENT_ID=
 AUTHENTIK_CLIENT_SECRET=

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ flask-socketio
 google-genai
 authlib
 PyJWT
+argon2-cffi
 beautifulsoup4

--- a/tests/app_harness.py
+++ b/tests/app_harness.py
@@ -1,0 +1,63 @@
+"""Run a snippet against a freshly imported app, in its own interpreter.
+
+AUTH_MODE is read once when `app` is imported, and it decides whether the OIDC
+client gets registered, so one interpreter can only ever host one mode. Tests
+that need a mode other than the one already imported have to fork.
+
+Also keeps these tests from dictating import order for anything else that
+imports the Flask app: whichever test module imports it first would otherwise
+fix the mode for the whole run.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Cleared so a developer's real SSO configuration cannot change what a test
+# asserts, and so each run starts from the documented defaults.
+_STRIPPED = (
+    'AUTH_MODE', 'AUTH_LOCAL_USERNAME',
+    'AUTHENTIK_CLIENT_ID', 'AUTHENTIK_CLIENT_SECRET',
+)
+
+
+def run(script: str, **env_overrides) -> subprocess.CompletedProcess:
+    """Run `script` against a fresh app import and an isolated DATA_DIR.
+
+    The script gets an `emit(**kwargs)` helper; call it once with everything the
+    assertions need, since only the parent process can assert.
+    """
+    env = os.environ.copy()
+    env['DATA_DIR'] = tempfile.mkdtemp()
+    for key in _STRIPPED:
+        env.pop(key, None)
+    env.update(env_overrides)
+
+    preamble = textwrap.dedent(f"""
+        import json, sys
+        sys.path.insert(0, {ROOT!r})
+        sys.path.insert(0, {os.path.join(ROOT, 'ui')!r})
+
+        def emit(**kw):
+            print('__RESULT__' + json.dumps(kw))
+    """)
+    return subprocess.run(
+        [sys.executable, '-c', preamble + textwrap.dedent(script)],
+        capture_output=True, text=True, env=env, cwd=ROOT, timeout=180,
+    )
+
+
+def result(proc: subprocess.CompletedProcess) -> dict:
+    """Parse what the script emitted, or fail with its full output."""
+    for line in proc.stdout.splitlines():
+        if line.startswith('__RESULT__'):
+            return json.loads(line[len('__RESULT__'):])
+    raise AssertionError(
+        f'no result emitted (exit={proc.returncode})\n'
+        f'--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}'
+    )

--- a/tests/test_auth_mode.py
+++ b/tests/test_auth_mode.py
@@ -1,4 +1,4 @@
-"""Tests for AUTH_MODE — running with and without Authentik SSO (issue #13).
+"""Tests for AUTH_MODE — local password accounts versus Authentik SSO.
 
 Each scenario runs in its own subprocess: AUTH_MODE is read once when `app` is
 imported, so two modes cannot coexist in a single interpreter. Isolation also
@@ -6,190 +6,194 @@ keeps these tests from dictating import order for anything else that imports
 the Flask app.
 """
 
-import json
-import os
-import subprocess
-import sys
-import tempfile
-import textwrap
 import unittest
 
-ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+from app_harness import result as _result, run as _run
 
 
-def _run(script: str, **env_overrides) -> subprocess.CompletedProcess:
-    """Run `script` against a fresh app import and isolated DATA_DIR."""
-    env = os.environ.copy()
-    env['DATA_DIR'] = tempfile.mkdtemp()
-    # Never inherit the developer's real SSO config.
-    for key in ('AUTH_MODE', 'AUTH_LOCAL_USERNAME',
-                'AUTHENTIK_CLIENT_ID', 'AUTHENTIK_CLIENT_SECRET'):
-        env.pop(key, None)
-    env.update(env_overrides)
+class TestDefaultModeIsLocal(unittest.TestCase):
+    """A container started with no configuration must be usable, and closed.
 
-    preamble = textwrap.dedent(f"""
-        import json, sys
-        sys.path.insert(0, {ROOT!r})
-        sys.path.insert(0, {os.path.join(ROOT, 'ui')!r})
-
-        def emit(**kw):
-            print('__RESULT__' + json.dumps(kw))
-    """)
-    return subprocess.run(
-        [sys.executable, '-c', preamble + textwrap.dedent(script)],
-        capture_output=True, text=True, env=env, cwd=ROOT, timeout=180,
-    )
-
-
-def _result(proc: subprocess.CompletedProcess) -> dict:
-    for line in proc.stdout.splitlines():
-        if line.startswith('__RESULT__'):
-            return json.loads(line[len('__RESULT__'):])
-    raise AssertionError(
-        f'no result emitted (exit={proc.returncode})\n'
-        f'--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}'
-    )
-
-
-class TestAuthModeNone(unittest.TestCase):
-    """AUTH_MODE=none must make the app usable with no identity provider."""
+    This is the issue #13 requirement: no identity provider needed. It is met by
+    local accounts rather than by disabling authentication, so the instance is
+    never open to whoever reaches the port.
+    """
 
     @classmethod
     def setUpClass(cls):
         proc = _run("""
-            from app import app
+            from app import app, AUTH_MODE, LOCAL_AUTH
             app.config['TESTING'] = True
             client = app.test_client()
 
             jobs = client.get('/api/jobs')
-            me = client.get('/api/me')
             status = client.get('/api/auth/status')
             login = client.get('/login')
-            logout = client.get('/logout')
-            sso = client.get('/auth/login')
+            setup = client.get('/setup')
 
             emit(
+                auth_mode=AUTH_MODE,
+                local_auth=LOCAL_AUTH,
                 jobs_status=jobs.status_code,
-                me_status=me.status_code,
-                me=me.get_json(),
                 auth_status=status.get_json(),
                 login_status=login.status_code,
                 login_location=login.headers.get('Location'),
-                logout_status=logout.status_code,
-                logout_location=logout.headers.get('Location'),
-                sso_status=sso.status_code,
-                sso_location=sso.headers.get('Location'),
+                setup_status=setup.status_code,
             )
-        """, AUTH_MODE='none')
+        """)
+        cls.proc = proc
         cls.res = _result(proc)
 
-    def test_protected_api_reachable_without_login(self):
-        self.assertEqual(self.res['jobs_status'], 200)
+    def test_local_is_the_default_mode(self):
+        self.assertEqual(self.res['auth_mode'], 'local')
+        self.assertTrue(self.res['local_auth'])
 
-    def test_requests_run_as_local_admin(self):
-        self.assertEqual(self.res['me_status'], 200)
-        self.assertEqual(self.res['me']['user'], 'local')
-        self.assertTrue(self.res['me']['is_admin'])
-        self.assertTrue(self.res['me']['auth_disabled'])
+    def test_api_still_requires_authentication(self):
+        """No mode leaves the API open; Settings holds third-party API keys."""
+        self.assertEqual(self.res['jobs_status'], 401)
 
-    def test_auth_status_reports_disabled(self):
-        self.assertFalse(self.res['auth_status']['sso_enabled'])
-        self.assertTrue(self.res['auth_status']['auth_disabled'])
+    def test_status_advertises_mode_and_setup(self):
+        status = self.res['auth_status']
+        self.assertEqual(status['auth_mode'], 'local')
+        self.assertTrue(status['local_auth_enabled'])
+        self.assertTrue(status['setup_required'])
+        self.assertFalse(status['sso_enabled'])
+        self.assertFalse(status['auth_disabled'])
 
-    def test_login_page_redirects_to_app(self):
+    def test_login_sends_a_fresh_instance_to_setup(self):
         self.assertEqual(self.res['login_status'], 302)
-        self.assertEqual(self.res['login_location'], '/')
+        self.assertIn('/setup', self.res['login_location'])
 
-    def test_logout_is_a_noop_redirect(self):
-        self.assertEqual(self.res['logout_status'], 302)
-        self.assertEqual(self.res['logout_location'], '/')
-
-    def test_sso_entrypoint_redirects_instead_of_erroring(self):
-        self.assertEqual(self.res['sso_status'], 302)
-        self.assertEqual(self.res['sso_location'], '/')
+    def test_setup_page_is_reachable(self):
+        self.assertEqual(self.res['setup_status'], 200)
 
 
-class TestAuthModeNoneLocalUser(unittest.TestCase):
-    def test_local_username_is_configurable_and_persisted(self):
-        proc = _run("""
-            from app import app
-            from database import get_user
-            app.config['TESTING'] = True
-            row = get_user('chef')
-            me = app.test_client().get('/api/me').get_json()
-            emit(
-                user_row_exists=row is not None,
-                user_row_is_admin=bool(row and row['is_admin']),
-                user_row_has_no_oidc_sub=bool(row and row['oidc_sub'] is None),
-                me_user=me['user'],
-            )
-        """, AUTH_MODE='none', AUTH_LOCAL_USERNAME='chef')
-        res = _result(proc)
-        self.assertTrue(res['user_row_exists'])
-        self.assertTrue(res['user_row_is_admin'])
-        self.assertTrue(res['user_row_has_no_oidc_sub'])
-        self.assertEqual(res['me_user'], 'chef')
+class TestAuthModeNoneIsMigrated(unittest.TestCase):
+    """AUTH_MODE=none is gone, but deployments still carrying it must boot.
 
-
-class TestDefaultModeStillProtected(unittest.TestCase):
-    """Regression guard: the default must never fall open (issue #13 fix)."""
+    They land on setup, and setup adopts the passwordless account that mode
+    created so its job history stays attached to the same username.
+    """
 
     @classmethod
     def setUpClass(cls):
         proc = _run("""
-            from app import app
+            import database
+            from app import app, AUTH_MODE
+
+            # Stand in for an instance that previously ran AUTH_MODE=none: the
+            # account exists with no password, and owns a job.
+            database.ensure_local_user('local')
+
+            app.config['TESTING'] = True
+            client = app.test_client()
+            status = client.get('/api/auth/status')
+
+            created = client.post('/setup', data={
+                'username': 'local',
+                'password': 'correct horse battery',
+                'confirm_password': 'correct horse battery',
+            })
+            row = database.get_user('local')
+            users = database.get_db_user_count() if hasattr(
+                database, 'get_db_user_count') else None
+
+            emit(
+                auth_mode=AUTH_MODE,
+                setup_required=status.get_json()['setup_required'],
+                setup_status=created.status_code,
+                adopted_has_password=bool(row and row.get('password_hash')),
+                adopted_is_admin=bool(row and row['is_admin']),
+                adopted_has_no_oidc_sub=(row or {}).get('oidc_sub') is None,
+            )
+        """, AUTH_MODE='none')
+        cls.proc = proc
+        cls.res = _result(proc)
+
+    def test_none_is_accepted_and_treated_as_local(self):
+        self.assertEqual(self.res['auth_mode'], 'local')
+
+    def test_it_warns_rather_than_failing_to_boot(self):
+        self.assertIn('AUTH_MODE=none is no longer supported', self.proc.stdout)
+
+    def test_the_instance_needs_setup(self):
+        self.assertTrue(self.res['setup_required'])
+
+    def test_setup_adopts_the_existing_account(self):
+        """Reusing the row keeps history attached; a new username would orphan it."""
+        self.assertEqual(self.res['setup_status'], 302)
+        self.assertTrue(self.res['adopted_has_password'])
+        self.assertTrue(self.res['adopted_is_admin'])
+        self.assertTrue(self.res['adopted_has_no_oidc_sub'])
+
+
+class TestAuthentikMode(unittest.TestCase):
+    """AUTH_MODE=authentik keeps the SSO-only behaviour."""
+
+    @classmethod
+    def setUpClass(cls):
+        proc = _run("""
+            from app import app, AUTH_MODE, LOCAL_AUTH
             app.config['TESTING'] = True
             client = app.test_client()
 
-            jobs = client.get('/api/jobs')
-            login = client.get('/login')
             status = client.get('/api/auth/status')
-
-            authed = app.test_client()
-            with authed.session_transaction() as sess:
-                sess['user'] = 'someone'
-                sess['is_admin'] = False
+            jobs = client.get('/api/jobs')
+            form_login = client.post('/auth/local/login', data={
+                'username': 'someone', 'password': 'whatever-they-typed',
+            })
+            json_login = client.post('/auth/local/login', json={
+                'username': 'someone', 'password': 'whatever-they-typed',
+            })
+            after = client.get('/api/jobs')
 
             emit(
-                jobs_status=jobs.status_code,
-                jobs_body=jobs.get_json(),
-                login_status=login.status_code,
+                auth_mode=AUTH_MODE,
+                local_auth=LOCAL_AUTH,
                 auth_status=status.get_json(),
-                authed_jobs_status=authed.get('/api/jobs').status_code,
+                jobs_status=jobs.status_code,
+                form_login_status=form_login.status_code,
+                form_login_location=form_login.headers.get('Location'),
+                json_login_status=json_login.status_code,
+                still_unauthenticated=after.status_code,
             )
-        """)
+        """, AUTH_MODE='authentik',
+             AUTHENTIK_CLIENT_ID='cid', AUTHENTIK_CLIENT_SECRET='secret')
         cls.res = _result(proc)
 
-    def test_protected_api_still_401_without_session(self):
+    def test_mode_reported(self):
+        self.assertEqual(self.res['auth_mode'], 'authentik')
+        self.assertFalse(self.res['local_auth'])
+
+    def test_no_setup_needed(self):
+        """Accounts arrive from the provider, so there is nothing to bootstrap."""
+        status = self.res['auth_status']
+        self.assertFalse(status['setup_required'])
+        self.assertFalse(status['local_auth_enabled'])
+        self.assertTrue(status['sso_enabled'])
+
+    def test_api_protected(self):
         self.assertEqual(self.res['jobs_status'], 401)
-        self.assertEqual(self.res['jobs_body']['error'], 'Authentication required')
 
-    def test_cookie_session_still_authenticates(self):
-        self.assertEqual(self.res['authed_jobs_status'], 200)
-
-    def test_login_page_served_so_the_error_is_visible(self):
-        self.assertEqual(self.res['login_status'], 200)
-
-    def test_auth_status_reports_enabled_mode(self):
-        self.assertFalse(self.res['auth_status']['sso_enabled'])
-        self.assertFalse(self.res['auth_status']['auth_disabled'])
+    def test_password_login_is_refused(self):
+        """Otherwise SSO could be bypassed by any account holding a password."""
+        # A browser gets sent back to the login page; the SPA gets a status.
+        self.assertEqual(self.res['form_login_status'], 302)
+        self.assertIn('/login', self.res['form_login_location'])
+        self.assertEqual(self.res['json_login_status'], 400)
+        # Above all: no session was established either way.
+        self.assertEqual(self.res['still_unauthenticated'], 401)
 
 
 class TestInvalidAuthMode(unittest.TestCase):
-    def test_typo_fails_fast_instead_of_falling_open(self):
+    def test_unknown_mode_fails_loudly_at_boot(self):
         proc = _run("""
-            try:
-                import app
-            except RuntimeError as exc:
-                emit(error=str(exc))
-            else:
-                emit(error=None)
+            import app  # noqa: F401
+            emit(ok=True)
         """, AUTH_MODE='disabled')
-        res = _result(proc)
-        self.assertIsNotNone(
-            res['error'], 'an unrecognised AUTH_MODE must not boot the app'
-        )
-        self.assertIn('AUTH_MODE', res['error'])
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn('AUTH_MODE', proc.stderr)
+        self.assertIn('local', proc.stderr)
 
 
 if __name__ == '__main__':

--- a/tests/test_baseline_http_auth.py
+++ b/tests/test_baseline_http_auth.py
@@ -20,6 +20,9 @@ sys.path.insert(0, os.path.join(ROOT, 'ui'))
 
 _test_dir = tempfile.mkdtemp()
 os.environ['DATA_DIR'] = _test_dir
+# These characterize the OIDC cookie-session path, so pin the mode rather than
+# inheriting a default. In local mode a fresh instance sends /login to /setup.
+os.environ['AUTH_MODE'] = 'authentik'
 
 
 class TestBaselineHttpAuth(unittest.TestCase):

--- a/tests/test_local_auth.py
+++ b/tests/test_local_auth.py
@@ -1,0 +1,543 @@
+"""Tests for local username and password accounts.
+
+Split in two. The hashing tests touch only `passwords`, so they run in-process.
+Everything that needs the Flask app runs in a forked interpreter via
+app_harness: importing `app` fixes AUTH_MODE for the whole process, and the
+SSO suites in this same run need it left on `authentik`.
+
+One fork per class rather than per test, so the cost of importing the app is
+paid a handful of times instead of thirty.
+"""
+
+import os
+import sys
+import textwrap
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'ui'))
+
+from app_harness import result as _result, run as _run  # noqa: E402
+
+import passwords  # noqa: E402
+
+GOOD_PASSWORD = 'a properly long passphrase'
+
+# Prelude shared by the forked scripts: local mode, an empty users table, and a
+# helper that creates the first account without going through the HTTP flow.
+_PRELUDE = f"""
+    import database, login_throttle, passwords
+    from app import app
+
+    GOOD_PASSWORD = {GOOD_PASSWORD!r}
+    app.config['TESTING'] = True
+
+    def make_admin(username='admin', password=GOOD_PASSWORD):
+        return database.claim_first_local_admin(
+            username, passwords.hash_password(password)
+        )
+"""
+
+
+def _run_local(script: str, **env) -> dict:
+    # Dedented separately: the two literals are indented differently, and
+    # dedent only strips the indent common to everything it is given.
+    combined = textwrap.dedent(_PRELUDE) + textwrap.dedent(script)
+    return _result(_run(combined, **env))
+
+
+class TestPasswordHashing(unittest.TestCase):
+    """Pure hashing behaviour; no Flask app involved."""
+
+    def test_hash_is_argon2id_and_salted(self):
+        first = passwords.hash_password(GOOD_PASSWORD)
+        second = passwords.hash_password(GOOD_PASSWORD)
+        self.assertTrue(first.startswith('$argon2id$'))
+        # Distinct salts, so identical passwords do not share a hash and a
+        # stolen database cannot be scanned for repeats.
+        self.assertNotEqual(first, second)
+
+    def test_verify_accepts_the_password_and_rejects_others(self):
+        stored = passwords.hash_password(GOOD_PASSWORD)
+        self.assertTrue(passwords.verify(stored, GOOD_PASSWORD))
+        self.assertFalse(passwords.verify(stored, GOOD_PASSWORD + 'x'))
+        self.assertFalse(passwords.verify(stored, ''))
+
+    def test_verify_is_false_for_accounts_without_a_password(self):
+        """An OIDC or admin-created row must not be signable-into."""
+        self.assertFalse(passwords.verify(None, GOOD_PASSWORD))
+        self.assertFalse(passwords.verify('', GOOD_PASSWORD))
+
+    def test_verify_survives_a_corrupt_hash(self):
+        self.assertFalse(passwords.verify('not-a-hash', GOOD_PASSWORD))
+
+    def test_length_policy(self):
+        with self.assertRaises(passwords.WeakPassword):
+            passwords.hash_password('short')
+        with self.assertRaises(passwords.WeakPassword):
+            passwords.hash_password('')
+        with self.assertRaises(passwords.WeakPassword):
+            passwords.hash_password('x' * (passwords.MAX_PASSWORD_LENGTH + 1))
+
+    def test_no_composition_rules(self):
+        """Length is the requirement; a long lowercase phrase is fine."""
+        self.assertTrue(passwords.hash_password('all lowercase words here'))
+
+    def test_rehash_detects_outdated_parameters(self):
+        from argon2 import PasswordHasher
+        weak = PasswordHasher(time_cost=1, memory_cost=8, parallelism=1).hash(
+            GOOD_PASSWORD
+        )
+        self.assertTrue(passwords.needs_rehash(weak))
+        self.assertFalse(passwords.needs_rehash(passwords.hash_password(GOOD_PASSWORD)))
+
+
+class TestFirstRunSetup(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            client = app.test_client()
+            page = client.get('/setup')
+
+            created = client.post('/setup', data={
+                'username': 'chef',
+                'password': GOOD_PASSWORD,
+                'confirm_password': GOOD_PASSWORD,
+            })
+            row = database.get_user('chef')
+            authed_after_setup = client.get('/api/jobs').status_code
+
+            # Setup must now be closed to everyone, including a second visitor.
+            other = app.test_client()
+            reget = other.get('/setup')
+            usurp = other.post('/setup', data={
+                'username': 'usurper',
+                'password': GOOD_PASSWORD,
+                'confirm_password': GOOD_PASSWORD,
+            })
+
+            emit(
+                page_status=page.status_code,
+                page_has_form=b'Create account' in page.data,
+                created_status=created.status_code,
+                row_is_admin=bool(row and row['is_admin']),
+                row_hash_is_argon2id=(row or {}).get(
+                    'password_hash', '').startswith('$argon2id$'),
+                authed_after_setup=authed_after_setup,
+                reget_status=reget.status_code,
+                reget_location=reget.headers.get('Location'),
+                usurp_status=usurp.status_code,
+                usurper_created=database.get_user('usurper') is not None,
+            )
+        """)
+
+    def test_setup_page_served_while_no_account_exists(self):
+        self.assertEqual(self.res['page_status'], 200)
+        self.assertTrue(self.res['page_has_form'])
+
+    def test_setup_creates_an_admin(self):
+        self.assertEqual(self.res['created_status'], 302)
+        self.assertTrue(self.res['row_is_admin'])
+        self.assertTrue(self.res['row_hash_is_argon2id'])
+
+    def test_setup_signs_the_new_admin_in(self):
+        """Being made to log in with credentials just chosen is pure friction."""
+        self.assertEqual(self.res['authed_after_setup'], 200)
+
+    def test_setup_closes_once_an_account_exists(self):
+        self.assertEqual(self.res['reget_status'], 302)
+        self.assertIn('/login', self.res['reget_location'])
+        self.assertEqual(self.res['usurp_status'], 302)
+        self.assertFalse(
+            self.res['usurper_created'],
+            'a second visitor must not be able to claim an account',
+        )
+
+
+class TestSetupValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            def attempt(**form):
+                client = app.test_client()
+                resp = client.post('/setup', data=form)
+                return {
+                    'status': resp.status_code,
+                    'body': resp.get_data(as_text=True),
+                    'created': database.local_account_exists(),
+                }
+
+            mismatch = attempt(username='chef', password=GOOD_PASSWORD,
+                               confirm_password=GOOD_PASSWORD + 'typo')
+            short = attempt(username='chef', password='abc',
+                            confirm_password='abc')
+            blank_user = attempt(username='   ', password=GOOD_PASSWORD,
+                                 confirm_password=GOOD_PASSWORD)
+            long_user = attempt(username='x' * 65, password=GOOD_PASSWORD,
+                                confirm_password=GOOD_PASSWORD)
+
+            emit(mismatch=mismatch, short=short,
+                 blank_user=blank_user, long_user=long_user)
+        """)
+
+    def _assert_rejected(self, case, expect_text=None):
+        self.assertEqual(case['status'], 400)
+        self.assertFalse(case['created'], 'a rejected submission must create nothing')
+        if expect_text:
+            self.assertIn(expect_text, case['body'])
+
+    def test_mismatched_passwords_rejected(self):
+        self._assert_rejected(self.res['mismatch'], 'do not match')
+
+    def test_short_password_rejected(self):
+        self._assert_rejected(self.res['short'], 'at least')
+
+    def test_blank_username_rejected(self):
+        self._assert_rejected(self.res['blank_user'])
+
+    def test_overlong_username_rejected(self):
+        self._assert_rejected(self.res['long_user'])
+
+
+class TestSetupRaceAndAdoption(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            # Two claims in a row stand in for two concurrent submissions: the
+            # guard and the write share one transaction, so the loser gets None.
+            first = make_admin('first')
+            second = make_admin('second')
+
+            # Fresh database for the adoption case.
+            with database.get_db() as conn:
+                conn.execute('DELETE FROM users')
+                conn.commit()
+
+            # An instance upgrading from AUTH_MODE=none: the account exists with
+            # no password, and every job recorded ownership against its name.
+            database.ensure_local_user('local')
+            needs_setup_with_passwordless_row = database.local_account_exists()
+
+            # The name the setup form offers. It has to be the existing one, or
+            # the obvious path through the form orphans that account's history.
+            suggested = app.test_client().get('/setup').get_data(as_text=True)
+
+            adopted = make_admin('local')
+            row = database.get_user('local')
+            with database.get_db() as conn:
+                user_count = conn.execute('SELECT COUNT(*) FROM users').fetchone()[0]
+
+            emit(
+                first_claimed=first is not None,
+                second_claimed=second is not None,
+                second_row_exists=database.get_user('second') is not None,
+                needs_setup_with_passwordless_row=needs_setup_with_passwordless_row,
+                setup_page_offers_existing_name='value="local"' in suggested,
+                adopted=adopted is not None,
+                adopted_has_password=bool(row and row['password_hash']),
+                adopted_is_admin=bool(row and row['is_admin']),
+                adopted_oidc_sub_is_null=(row or {}).get('oidc_sub') is None,
+                user_count=user_count,
+            )
+        """)
+
+    def test_only_one_claim_can_win(self):
+        self.assertTrue(self.res['first_claimed'])
+        self.assertFalse(self.res['second_claimed'])
+        self.assertFalse(self.res['second_row_exists'])
+
+    def test_a_passwordless_row_does_not_count_as_an_account(self):
+        """Otherwise an upgraded instance would show a form nobody can satisfy."""
+        self.assertFalse(self.res['needs_setup_with_passwordless_row'])
+
+    def test_setup_adopts_the_passwordless_row(self):
+        self.assertTrue(self.res['adopted'])
+        self.assertTrue(self.res['adopted_has_password'])
+        self.assertTrue(self.res['adopted_is_admin'])
+        self.assertTrue(self.res['adopted_oidc_sub_is_null'])
+
+    def test_adoption_reuses_the_row_rather_than_adding_one(self):
+        """A new username would orphan the history owned by the old one."""
+        self.assertEqual(self.res['user_count'], 1)
+
+    def test_setup_offers_the_adoptable_username(self):
+        """Ownership is stored as the username, so adoption hinges on the name.
+
+        The default suggestion is 'admin', which would not match the 'local'
+        that AUTH_MODE=none seeded — accepting the form as presented has to keep
+        the history rather than silently stranding it.
+        """
+        self.assertTrue(self.res['setup_page_offers_existing_name'])
+
+
+class TestLocalLogin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            make_admin('chef')
+
+            ok_client = app.test_client()
+            ok = ok_client.post('/auth/local/login', data={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+            authed = ok_client.get('/api/jobs').status_code
+            me = ok_client.get('/api/me').get_json()
+
+            json_client = app.test_client()
+            json_ok = json_client.post('/auth/local/login', json={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+
+            bad_client = app.test_client()
+            wrong = bad_client.post('/auth/local/login', json={
+                'username': 'chef', 'password': 'not the password',
+            })
+            still_out = bad_client.get('/api/jobs').status_code
+
+            missing = app.test_client().post('/auth/local/login', json={
+                'username': 'nobody', 'password': 'not the password',
+            })
+
+            # An account with no password must not be reachable with an empty one.
+            database.ensure_local_user('sso-user', is_admin=False)
+            passwordless = app.test_client().post('/auth/local/login', json={
+                'username': 'sso-user', 'password': '',
+            })
+
+            emit(
+                ok_status=ok.status_code,
+                authed=authed,
+                me=me,
+                json_status=json_ok.status_code,
+                json_body=json_ok.get_json(),
+                wrong_status=wrong.status_code,
+                wrong_error=wrong.get_json()['error'],
+                still_out=still_out,
+                missing_status=missing.status_code,
+                missing_error=missing.get_json()['error'],
+                passwordless_status=passwordless.status_code,
+            )
+        """)
+
+    def test_correct_credentials_sign_in(self):
+        self.assertEqual(self.res['ok_status'], 302)
+        self.assertEqual(self.res['authed'], 200)
+        self.assertEqual(self.res['me']['user'], 'chef')
+        self.assertTrue(self.res['me']['is_admin'])
+        self.assertEqual(self.res['me']['auth_mode'], 'local')
+
+    def test_json_callers_get_the_identity_back(self):
+        self.assertEqual(self.res['json_status'], 200)
+        self.assertEqual(self.res['json_body'], {'user': 'chef', 'is_admin': True})
+
+    def test_wrong_password_is_refused(self):
+        self.assertEqual(self.res['wrong_status'], 401)
+        self.assertEqual(self.res['still_out'], 401)
+
+    def test_unknown_user_and_wrong_password_are_indistinguishable(self):
+        """Differing responses would enumerate which accounts exist."""
+        self.assertEqual(self.res['wrong_status'], self.res['missing_status'])
+        self.assertEqual(self.res['wrong_error'], self.res['missing_error'])
+        self.assertEqual(self.res['wrong_error'], 'Invalid username or password.')
+
+    def test_account_without_a_password_cannot_sign_in(self):
+        self.assertEqual(self.res['passwordless_status'], 401)
+
+
+class TestSessionHandling(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            make_admin('chef')
+
+            # A planted session value must not survive the privilege change.
+            fixation = app.test_client()
+            with fixation.session_transaction() as sess:
+                sess['planted'] = 'attacker-controlled'
+            fixation.post('/auth/local/login', data={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+            with fixation.session_transaction() as sess:
+                planted_survived = 'planted' in sess
+                user_after = sess.get('user')
+
+            # A pending share is the reason the user was sent to log in.
+            share = app.test_client()
+            with share.session_transaction() as sess:
+                sess['shared_url'] = 'https://example.com/reel'
+            share.post('/auth/local/login', data={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+            shared_after = share.get('/api/me').get_json()['shared_url']
+
+            out = app.test_client()
+            out.post('/auth/local/login', data={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+            out.get('/logout')
+            after_logout = out.get('/api/jobs').status_code
+            with out.session_transaction() as sess:
+                user_key_remains = 'user' in sess
+
+            emit(
+                planted_survived=planted_survived,
+                user_after=user_after,
+                shared_after=shared_after,
+                after_logout=after_logout,
+                user_key_remains=user_key_remains,
+            )
+        """)
+
+    def test_session_is_rotated_on_sign_in(self):
+        self.assertFalse(self.res['planted_survived'])
+        self.assertEqual(self.res['user_after'], 'chef')
+
+    def test_pending_share_survives_sign_in(self):
+        self.assertEqual(self.res['shared_after'], 'https://example.com/reel')
+
+    def test_logout_clears_everything(self):
+        self.assertEqual(self.res['after_logout'], 401)
+        self.assertFalse(self.res['user_key_remains'])
+
+
+class TestRehashOnLogin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            from argon2 import PasswordHasher
+            weak = PasswordHasher(time_cost=1, memory_cost=8, parallelism=1).hash(
+                GOOD_PASSWORD
+            )
+            database.claim_first_local_admin('chef', weak)
+
+            app.test_client().post('/auth/local/login', data={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+            stored = database.get_user('chef')['password_hash']
+
+            emit(
+                was_outdated=passwords.needs_rehash(weak),
+                changed=stored != weak,
+                now_current=not passwords.needs_rehash(stored),
+                still_verifies=passwords.verify(stored, GOOD_PASSWORD),
+            )
+        """)
+
+    def test_outdated_hash_is_upgraded_on_login(self):
+        """The password is in hand only during login; it is the one chance."""
+        self.assertTrue(self.res['was_outdated'])
+        self.assertTrue(self.res['changed'])
+        self.assertTrue(self.res['now_current'])
+
+    def test_upgraded_hash_still_accepts_the_password(self):
+        self.assertTrue(self.res['still_verifies'])
+
+
+class TestLoginThrottling(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            make_admin('chef')
+
+            def wrong_attempts(username, n):
+                client = app.test_client()
+                return [
+                    client.post('/auth/local/login', json={
+                        'username': username, 'password': 'wrong',
+                    }).status_code
+                    for _ in range(n)
+                ]
+
+            statuses = wrong_attempts('chef', 6)
+            throttled = app.test_client().post('/auth/local/login', json={
+                'username': 'chef', 'password': 'wrong',
+            })
+
+            # Under the free-attempt threshold, the right password still works.
+            login_throttle.clear_all()
+            wrong_attempts('chef', 3)
+            recovers = app.test_client().post('/auth/local/login', json={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            }).status_code
+
+            # A success clears the counter, so an earlier typo leaves no penalty.
+            login_throttle.clear_all()
+            wrong_attempts('chef', 3)
+            app.test_client().post('/auth/local/login', json={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            })
+            after_success = app.test_client().post('/auth/local/login', json={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            }).status_code
+
+            # Hammering one name must not lock a different one out.
+            login_throttle.clear_all()
+            wrong_attempts('someone-else', 8)
+            other_unaffected = app.test_client().post('/auth/local/login', json={
+                'username': 'chef', 'password': GOOD_PASSWORD,
+            }).status_code
+
+            emit(
+                statuses=statuses,
+                throttled_status=throttled.status_code,
+                retry_after=throttled.headers.get('Retry-After'),
+                recovers=recovers,
+                after_success=after_success,
+                other_unaffected=other_unaffected,
+            )
+        """)
+
+    def test_repeated_failures_start_being_throttled(self):
+        self.assertIn(429, self.res['statuses'],
+                      f"never throttled: {self.res['statuses']}")
+
+    def test_first_attempts_are_not_throttled(self):
+        """A mistyped password should not be met with a delay straight away."""
+        self.assertEqual(self.res['statuses'][:3], [401, 401, 401])
+
+    def test_throttled_response_says_when_to_retry(self):
+        self.assertEqual(self.res['throttled_status'], 429)
+        self.assertIsNotNone(self.res['retry_after'])
+
+    def test_correct_password_works_below_the_threshold(self):
+        self.assertEqual(self.res['recovers'], 200)
+
+    def test_a_successful_sign_in_clears_the_counter(self):
+        self.assertEqual(self.res['after_success'], 200)
+
+    def test_throttling_one_account_does_not_lock_out_another(self):
+        """Otherwise brute-force defence becomes a denial-of-service tool."""
+        self.assertEqual(self.res['other_unaffected'], 200)
+
+
+class TestAuthStatus(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            client = app.test_client()
+            before = client.get('/api/auth/status')
+            make_admin('secret-admin')
+            after = client.get('/api/auth/status')
+
+            emit(
+                before_status=before.status_code,
+                before=before.get_json(),
+                after=after.get_json(),
+                after_body=after.get_data(as_text=True),
+            )
+        """)
+
+    def test_status_is_public(self):
+        """The client needs it before it can possibly be authenticated."""
+        self.assertEqual(self.res['before_status'], 200)
+
+    def test_setup_required_flips_once_an_account_exists(self):
+        self.assertTrue(self.res['before']['setup_required'])
+        self.assertFalse(self.res['after']['setup_required'])
+
+    def test_status_never_leaks_a_username(self):
+        self.assertNotIn('secret-admin', self.res['after_body'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mobile_auth.py
+++ b/tests/test_mobile_auth.py
@@ -21,6 +21,10 @@ sys.path.insert(0, os.path.join(ROOT, 'ui'))
 
 _test_dir = tempfile.mkdtemp()
 os.environ['DATA_DIR'] = _test_dir
+# Explicit: app-based sign-in goes through the identity provider, which is only
+# registered in authentik mode. Relying on the default would tie these tests to
+# whatever that default happens to be.
+os.environ['AUTH_MODE'] = 'authentik'
 os.environ.setdefault('JWT_SECRET_KEY', 'unit-test-secret-key')
 os.environ.setdefault('AUTHENTIK_CLIENT_ID', 'test-client-id')
 os.environ.setdefault('AUTHENTIK_CLIENT_SECRET', 'test-client-secret')

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,7 +4,7 @@ A modern web interface for the Pick-a-Recipe video recipe extractor.
 
 ## Features
 
-- 🔐 **Authentik SSO (OIDC)** — no local passwords, or `AUTH_MODE=none` to run without sign-in
+- 🔐 **Local accounts or Authentik SSO (OIDC)** — chosen with `AUTH_MODE`
 - 📹 **URL Input** - Paste video URLs from TikTok, YouTube, Instagram, etc.
 - 📊 **Real-time Progress** - Watch the extraction process with live updates
 - ⚙️ **Configuration Management** - Save all settings through the web interface
@@ -64,13 +64,17 @@ docker run -d -p 5006:5006 -v pick-a-recipe-data:/app/data pickeld/pick-a-recipe
 
 ## Authentication
 
-Set by `AUTH_MODE`:
+Sign-in is always required. `AUTH_MODE` picks where accounts come from:
 
-- `authentik` (default) — sign-in required via Authentik single sign-on (OIDC).
-  Needs `AUTHENTIK_CLIENT_ID` and `AUTHENTIK_CLIENT_SECRET`.
-- `none` — no sign-in; every request runs as one local admin (`local`, or
-  `AUTH_LOCAL_USERNAME`). Convenient for local development, but there is no
-  access control whatsoever, so keep it off any untrusted network.
+- `local` (default) — username and password accounts stored by this app, hashed
+  with Argon2id. No identity provider needed: with no account yet, every page
+  redirects to `/setup`, which closes for good once one exists. Only an admin
+  can add further accounts; there is no self-registration.
+- `authentik` — Authentik single sign-on (OIDC). Needs `AUTHENTIK_CLIENT_ID` and
+  `AUTHENTIK_CLIENT_SECRET`. Password sign-in is refused in this mode.
+
+`AUTH_MODE=none` is gone. Instances still setting it boot with a warning as
+`local`, and setup adopts the old passwordless account so its data survives.
 
 The Android app in `../mobile/` uses JWT bearer tokens instead of cookies,
 enabled by setting `JWT_SECRET_KEY`. Bearer and cookie auth run side by side on
@@ -123,7 +127,8 @@ ui/
 The UI uses SQLite for data storage. A single database file is created in the project root:
 
 - `data/pick-a-recipe.db` - SQLite database containing:
-  - `users` table - User credentials (hashed passwords)
+  - `users` table - accounts; `password_hash` for local accounts, `oidc_sub` for
+    Authentik ones
   - `config` table - Configuration key-value pairs
 
 ## WebSocket Progress Events
@@ -141,8 +146,13 @@ The UI uses Socket.IO for real-time progress updates. The stages are:
 
 ## Security Notes
 
-- Authentication is delegated to Authentik single sign-on (OIDC) — no local passwords
-- Access requires membership in the configured Authentik user group; admin features require the admin group
-- `AUTH_MODE=none` disables authentication entirely and must only be used on a trusted network
+- Authentication cannot be switched off; Settings holds third-party API keys
+- Local passwords are Argon2id hashes with a per-account salt, rehashed on login
+  when cost parameters change; failed sign-ins are progressively delayed per
+  (IP, username) rather than locking the account
+- Wrong password and unknown username give the same response, so the login form
+  does not reveal which accounts exist
+- With Authentik, access requires membership in the configured user group; admin
+  features require the admin group
 - Session management uses Flask's secure sessions
 - API keys are stored in the local configuration file

--- a/ui/app.py
+++ b/ui/app.py
@@ -22,9 +22,13 @@ from flask import Flask, render_template, request, redirect, url_for, session, f
 from flask_socketio import SocketIO, emit, join_room, leave_room
 
 import mobile_auth
+import passwords
+import login_throttle
 from database import (
     init_db, load_config, save_config,
     get_user, upsert_oidc_user,
+    local_account_exists, claim_first_local_admin, set_user_password,
+    sole_passwordless_username,
     get_history, get_history_entry, get_history_count, delete_history_entry,
     delete_history_entries_bulk, delete_job_entry, delete_jobs_bulk,
     get_combined_history_and_jobs, get_combined_history_and_jobs_count,
@@ -186,19 +190,39 @@ except Exception as _health_exc:  # never let health checks block startup
 job_manager = init_job_manager(socketio)
 
 # ===== Authentication mode =====
-# 'authentik' (default) gates access behind Authentik single sign-on. 'none'
-# turns authentication off and serves every request as one implicit local admin,
-# for self-hosted setups that have no identity provider. Opting out is explicit
-# on purpose: an unauthenticated instance exposes the LLM/Mealie/Tandoor API keys
-# stored in Settings to anyone who can reach the port.
-AUTH_MODE = (os.environ.get('AUTH_MODE') or 'authentik').strip().lower()
-if AUTH_MODE not in ('authentik', 'none'):
+# 'local' (default) keeps username and password accounts in this app's own
+# database, so a fresh container works with no configuration beyond choosing a
+# password on first run. 'authentik' delegates to Authentik single sign-on.
+#
+# There is no way to turn authentication off. Settings holds the LLM, Mealie and
+# Tandoor API keys, so an open instance hands those to anyone who can reach the
+# port.
+_DEFAULT_LOCAL_USERNAME = 'admin'
+AUTH_MODE = (os.environ.get('AUTH_MODE') or 'local').strip().lower()
+
+if AUTH_MODE == 'none':
+    # Accepted rather than rejected so existing deployments still boot. They
+    # land on first-run setup, which adopts the passwordless account that this
+    # mode created and keeps its job history attached.
+    print("[Auth] WARNING: AUTH_MODE=none is no longer supported and has been "
+          "treated as AUTH_MODE=local. Authentication is now always on. Open "
+          "the app to set a password for the existing account; its history is "
+          "preserved. Update your configuration to AUTH_MODE=local.")
+    AUTH_MODE = 'local'
+
+if AUTH_MODE not in ('local', 'authentik'):
     raise RuntimeError(
-        f"Invalid AUTH_MODE={AUTH_MODE!r}. Use 'authentik' for Authentik single "
-        "sign-on (default), or 'none' to run without authentication."
+        f"Invalid AUTH_MODE={AUTH_MODE!r}. Use 'local' for username and password "
+        "accounts stored by this app (default), or 'authentik' for Authentik "
+        "single sign-on."
     )
-AUTH_DISABLED = AUTH_MODE == 'none'
-LOCAL_USERNAME = (os.environ.get('AUTH_LOCAL_USERNAME') or 'local').strip() or 'local'
+
+LOCAL_AUTH = AUTH_MODE == 'local'
+# Prefills the username field on the setup page. Only a default: whatever is
+# submitted there wins, so this is convenience, not configuration.
+LOCAL_USERNAME = (
+    os.environ.get('AUTH_LOCAL_USERNAME') or _DEFAULT_LOCAL_USERNAME
+).strip() or _DEFAULT_LOCAL_USERNAME
 
 # ===== Authentication via Authentik (OIDC) =====
 # Single sign-on through the self-hosted Authentik instance at auth.pickel.me.
@@ -213,12 +237,8 @@ AUTHENTIK_USER_GROUP = os.environ.get('AUTHENTIK_USER_GROUP', 'pick-a-recipe-use
 AUTHENTIK_ADMIN_GROUP = os.environ.get('AUTHENTIK_ADMIN_GROUP', 'admins')
 
 oauth = None
-if AUTH_DISABLED:
-    from database import ensure_local_user
-    ensure_local_user(LOCAL_USERNAME)
-    print(f"[Auth] WARNING: AUTH_MODE=none — authentication is DISABLED. Every "
-          f"request runs as local admin '{LOCAL_USERNAME}'. Only run this on a "
-          f"trusted network; do not expose it to the internet.")
+if LOCAL_AUTH:
+    print('[Auth] AUTH_MODE=local — sign in with an account stored by this app.')
 elif os.environ.get('AUTHENTIK_CLIENT_ID') and os.environ.get('AUTHENTIK_CLIENT_SECRET'):
     from authlib.integrations.flask_client import OAuth
     oauth = OAuth(app)
@@ -230,9 +250,9 @@ elif os.environ.get('AUTHENTIK_CLIENT_ID') and os.environ.get('AUTHENTIK_CLIENT_
         client_kwargs={'scope': 'openid email profile groups'},
     )
 else:
-    print('[Auth] WARNING: AUTHENTIK_CLIENT_ID / AUTHENTIK_CLIENT_SECRET are not set — '
-          'nobody can sign in. Configure Authentik OIDC, or set AUTH_MODE=none to '
-          'run without authentication.')
+    print('[Auth] WARNING: AUTH_MODE=authentik but AUTHENTIK_CLIENT_ID / '
+          'AUTHENTIK_CLIENT_SECRET are not set — nobody can sign in. Configure '
+          'Authentik OIDC, or drop AUTH_MODE to use local accounts instead.')
 
 
 def _bearer_identity() -> dict | None:
@@ -259,16 +279,12 @@ def _bearer_identity() -> dict | None:
 
 
 def _is_logged_in() -> bool:
-    if AUTH_DISABLED:
-        return True
     if 'user' in session:
         return True
     return _bearer_identity_safe() is not None
 
 
 def _current_user_is_admin() -> bool:
-    if AUTH_DISABLED:
-        return True
     bearer = _bearer_identity_safe()
     if bearer is not None:
         return bearer['is_admin']
@@ -283,27 +299,22 @@ def _bearer_identity_safe() -> dict | None:
 
 
 def _current_username() -> str | None:
-    """Effective owner for the request, independent of the session cookie.
-
-    WebSocket handlers can run before any HTTP request has seeded the session,
-    so AUTH_MODE=none needs a fallback that does not depend on the cookie.
-    """
-    if AUTH_DISABLED:
-        return session.get('user') or LOCAL_USERNAME
+    """Effective owner for the request: the session user, or a Bearer identity."""
     bearer = _bearer_identity_safe()
     if bearer is not None:
         return bearer['username']
     return session.get('user')
 
 
-@app.before_request
-def _seed_local_identity():
-    """AUTH_MODE=none has no login flow, so stamp the local identity onto the
-    session that the rest of the app reads for ownership scoping."""
-    if AUTH_DISABLED and session.get('user') != LOCAL_USERNAME:
-        session['user'] = LOCAL_USERNAME
-        session['is_admin'] = True
-        session.permanent = True
+def _setup_required() -> bool:
+    """True while local mode has no account anyone can sign in to.
+
+    Only ever True before the first password is set. Authentik mode never needs
+    setup: accounts arrive from the identity provider.
+    """
+    if not LOCAL_AUTH:
+        return False
+    return not local_account_exists()
 
 
 def _scope() -> tuple[str | None, bool]:
@@ -484,15 +495,193 @@ def share():
     return redirect(url_for('index'))
 
 
+# One message for every credential failure. Saying "no such user" or "wrong
+# password" would let anyone enumerate which accounts exist.
+_INVALID_CREDENTIALS = 'Invalid username or password.'
+
+
+def _client_ip() -> str:
+    """Best available client address, for throttling.
+
+    ProxyFix (applied above when TRUST_PROXY is on) has already resolved
+    X-Forwarded-For, so remote_addr is the caller rather than the proxy.
+    """
+    return request.remote_addr or 'unknown'
+
+
+def _wants_json() -> bool:
+    """True when the caller is the SPA rather than a plain form submission."""
+    if request.is_json:
+        return True
+    accept = request.accept_mimetypes
+    return accept['application/json'] > accept['text/html']
+
+
+def _establish_session(username: str, *, is_admin: bool) -> None:
+    """Start an authenticated session, discarding whatever preceded it.
+
+    The session is cleared before it is repopulated so that a fixated or stale
+    cookie cannot carry state across the privilege change. Anything the
+    anonymous /share flow parked is deliberately carried over: it is the whole
+    reason a user was sent to sign in.
+    """
+    pending_shared_url = session.get('shared_url')
+    pending_auto_start = session.get('auto_start_extraction')
+
+    session.clear()
+    session['user'] = username
+    session['is_admin'] = is_admin
+    session.permanent = True
+
+    if pending_shared_url:
+        session['shared_url'] = pending_shared_url
+    if pending_auto_start:
+        session['auto_start_extraction'] = True
+
+
+def _login_failed(message: str, status: int, *, retry_after: int | None = None):
+    """Report a failed sign-in, as JSON or a redirect depending on the caller."""
+    if _wants_json():
+        response = jsonify({'error': message})
+        response.status_code = status
+        if retry_after is not None:
+            response.headers['Retry-After'] = str(retry_after)
+        return response
+    flash(message, 'error')
+    response = redirect(url_for('login'))
+    if retry_after is not None:
+        response.headers['Retry-After'] = str(retry_after)
+    return response
+
+
 @app.route('/login')
 def login():
-    """Login page — single sign-on via Authentik."""
+    """Login page: a password form in local mode, an SSO button in Authentik mode."""
     if _is_logged_in():
         return redirect(url_for('index'))
+    if _setup_required():
+        return redirect(url_for('setup'))
     spa_login = os.path.join(FRONTEND_DIST, 'index.html')
     if os.path.exists(spa_login):
         return send_from_directory(FRONTEND_DIST, 'index.html')
-    return render_template('login.html', sso_enabled=oauth is not None)
+    return render_template(
+        'login.html',
+        sso_enabled=oauth is not None,
+        local_auth=LOCAL_AUTH,
+    )
+
+
+@app.route('/setup', methods=['GET', 'POST'])
+def setup():
+    """Create the first account, while the instance has none.
+
+    Served from a template rather than the SPA on purpose: this has to work
+    before the frontend bundle is necessarily built, and it is the only way
+    into a fresh instance.
+    """
+    if not _setup_required():
+        # Closed for good once an account exists, so this cannot be used to
+        # add a second admin or overwrite the first one's password.
+        return redirect(url_for('login'))
+
+    # An instance upgrading from AUTH_MODE=none already owns jobs and uploads
+    # under the name that mode seeded, and ownership is recorded as the username
+    # rather than the row id. Offering that name means the obvious path through
+    # this form keeps the history; typing a different one starts fresh.
+    adoptable = sole_passwordless_username()
+    suggested = adoptable or LOCAL_USERNAME
+
+    if request.method == 'GET':
+        return render_template(
+            'setup.html', suggested_username=suggested, adopting=adoptable
+        )
+
+    username = (request.form.get('username') or '').strip()
+    password = request.form.get('password') or ''
+    confirm = request.form.get('confirm_password') or ''
+
+    error = None
+    if not username:
+        error = 'Choose a username.'
+    elif len(username) > 64:
+        error = 'Username must be at most 64 characters.'
+    elif password != confirm:
+        error = 'The two passwords do not match.'
+    else:
+        try:
+            passwords.validate(password)
+        except passwords.WeakPassword as exc:
+            error = str(exc)
+
+    if error:
+        return render_template(
+            'setup.html',
+            suggested_username=username or suggested,
+            adopting=adoptable,
+            error=error,
+        ), 400
+
+    user = claim_first_local_admin(username, passwords.hash_password(password))
+    if user is None:
+        # Another request completed setup between the guard and the write.
+        return redirect(url_for('login'))
+
+    print(f"[Auth] first account created: {user['username']}")
+    _establish_session(user['username'], is_admin=True)
+    return redirect(url_for('index'))
+
+
+@app.route('/auth/local/login', methods=['POST'])
+def auth_local_login():
+    """Sign in with a username and password held by this app."""
+    if not LOCAL_AUTH:
+        return _login_failed('Password sign-in is disabled on this instance.', 400)
+    if _setup_required():
+        return redirect(url_for('setup'))
+
+    payload = request.get_json(silent=True) if request.is_json else None
+    source = payload if isinstance(payload, dict) else request.form
+    username = str(source.get('username') or '').strip()
+    password = str(source.get('password') or '')
+
+    # Keyed on both, so guessing many passwords for one account and one password
+    # across many accounts are both slowed. The client cannot influence the key
+    # beyond the username it is already trying.
+    throttle_key = f'{_client_ip()}|{username.lower()}'
+    wait = login_throttle.retry_after(throttle_key)
+    if wait > 0:
+        return _login_failed(
+            f'Too many attempts. Try again in {int(wait) + 1} seconds.',
+            429,
+            retry_after=int(wait) + 1,
+        )
+
+    user = get_user(username) if username else None
+    if user is None:
+        # Spend comparable time to a real check: otherwise a fast rejection
+        # reveals that the username does not exist.
+        passwords.dummy_verify()
+        login_throttle.record_failure(throttle_key)
+        return _login_failed(_INVALID_CREDENTIALS, 401)
+
+    if not passwords.verify(user.get('password_hash'), password):
+        login_throttle.record_failure(throttle_key)
+        return _login_failed(_INVALID_CREDENTIALS, 401)
+
+    login_throttle.reset(throttle_key)
+
+    # Cost parameters may have risen since this hash was stored; the password is
+    # in hand exactly once, so this is the only chance to upgrade it.
+    if passwords.needs_rehash(user['password_hash']):
+        set_user_password(user['username'], passwords.hash_password(password))
+
+    _establish_session(user['username'], is_admin=bool(user['is_admin']))
+    if _wants_json():
+        return jsonify({
+            'user': user['username'],
+            'is_admin': bool(user['is_admin']),
+        })
+    return redirect(url_for('index'))
 
 
 def _authentik_redirect_uri() -> str:
@@ -509,12 +698,13 @@ def _authentik_redirect_uri() -> str:
 @app.route('/auth/login')
 def auth_login():
     """Redirect the user to Authentik for authentication."""
-    if AUTH_DISABLED:
-        return redirect(url_for('index'))
     if oauth is None:
+        if LOCAL_AUTH:
+            # Nothing to redirect to; the password form is on the login page.
+            return redirect(url_for('login'))
         flash('Single sign-on is not configured. Set AUTHENTIK_CLIENT_ID and '
-              'AUTHENTIK_CLIENT_SECRET, or set AUTH_MODE=none to run without '
-              'authentication.', 'error')
+              'AUTHENTIK_CLIENT_SECRET, or drop AUTH_MODE to use local '
+              'accounts instead.', 'error')
         return redirect(url_for('login'))
     return oauth.authentik.authorize_redirect(_authentik_redirect_uri())
 
@@ -704,9 +894,6 @@ def auth_callback():
               'administrator to add you to the appropriate group in Authentik.', 'error')
         return redirect(url_for('login'))
 
-    pending_shared_url = session.get('shared_url')
-    pending_auto_start = session.get('auto_start_extraction')
-
     user = upsert_oidc_user(
         sub=sub,
         username=username,
@@ -716,15 +903,7 @@ def auth_callback():
         is_admin=is_admin,
     )
 
-    session.clear()
-    session['user'] = user['username']
-    session['is_admin'] = is_admin
-    session.permanent = True
-
-    if pending_shared_url:
-        session['shared_url'] = pending_shared_url
-    if pending_auto_start:
-        session['auto_start_extraction'] = True
+    _establish_session(user['username'], is_admin=is_admin)
 
     flash(f"Welcome, {user.get('name') or user['username']}!", 'success')
     return redirect(url_for('index'))
@@ -733,13 +912,9 @@ def auth_callback():
 @app.route('/logout')
 def logout():
     """Log out: clear the local session and end the Authentik session."""
-    if AUTH_DISABLED:
-        # Nothing to sign out of; _seed_local_identity would re-create the
-        # session on the next request anyway.
-        return redirect(url_for('index'))
-
-    session.pop('user', None)
-    session.pop('is_admin', None)
+    # Everything, not just the identity keys: a stale share or auto-start left
+    # behind would be picked up by whoever signs in next on this browser.
+    session.clear()
 
     end_session_url = None
     if oauth is not None:
@@ -1239,7 +1414,10 @@ def api_me():
     return jsonify({
         'user': session['user'],
         'is_admin': bool(session.get('is_admin', False)),
-        'auth_disabled': AUTH_DISABLED,
+        'auth_mode': AUTH_MODE,
+        # Retained so an older cached frontend bundle keeps working; there is no
+        # longer a mode in which authentication is off.
+        'auth_disabled': False,
         'shared_url': session.pop('shared_url', None),
         'auto_start': bool(session.pop('auto_start_extraction', False)),
     })
@@ -1248,9 +1426,14 @@ def api_me():
 @app.route('/api/auth/status', methods=['GET'])
 def api_auth_status():
     return jsonify({
+        'auth_mode': AUTH_MODE,
+        'local_auth_enabled': LOCAL_AUTH,
         'sso_enabled': oauth is not None,
-        'auth_disabled': AUTH_DISABLED,
+        # True only before the first account exists, so a client can send the
+        # user to setup instead of a sign-in form nobody can satisfy yet.
+        'setup_required': _setup_required(),
         'mobile_auth_enabled': mobile_auth.mobile_auth_enabled(),
+        'auth_disabled': False,
     })
 
 
@@ -1313,9 +1496,6 @@ def api_mobile_refresh():
 @app.route('/api/mobile/me', methods=['GET'])
 def api_mobile_me():
     """Identity behind the presented Bearer token."""
-    if AUTH_DISABLED:
-        return jsonify({'username': LOCAL_USERNAME, 'is_admin': True})
-
     identity = _bearer_identity_safe()
     if identity is None:
         return jsonify({'error': 'Authentication required'}), 401

--- a/ui/database.py
+++ b/ui/database.py
@@ -51,6 +51,7 @@ def init_db():
                 name TEXT,
                 avatar_url TEXT,
                 is_admin INTEGER DEFAULT 0,
+                password_hash TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ''')
@@ -142,15 +143,18 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     """Apply incremental schema migrations for existing databases."""
     cursor = conn.cursor()
 
-    # Legacy local-auth schema detected: rebuild the users table for OIDC-only
-    # auth. Previously created local/Google accounts are discarded (fresh
-    # start); job history and configuration are preserved.
-    cursor.execute('PRAGMA table_info(users)')
-    columns = {row[1] for row in cursor.fetchall()}
-    if columns and 'password_hash' in columns:
-        print('[DB] Rebuilding users table for OIDC-only auth (legacy local accounts removed)')
-        cursor.execute('DROP TABLE users')
-        conn.commit()
+    # Local password accounts live alongside OIDC ones, so a user row may carry
+    # a password_hash, an oidc_sub, or both. Nullable: OIDC users never get one.
+    #
+    # A previous migration dropped the whole users table on sight of this
+    # column, from when local accounts were being retired in favour of
+    # OIDC-only auth. It must not come back: _migrate_schema runs on every
+    # boot, so it would wipe accounts on restart and orphan the user_id
+    # ownership recorded against every job and upload.
+    try:
+        cursor.execute('ALTER TABLE users ADD COLUMN password_hash TEXT')
+    except sqlite3.OperationalError:
+        pass
 
     job_columns = {
         'retry_from_history_id': 'INTEGER',
@@ -268,10 +272,11 @@ def upsert_oidc_user(
 
 
 def ensure_local_user(username: str, *, is_admin: bool = True) -> Dict[str, Any]:
-    """Create or return the built-in account used when AUTH_MODE=none.
+    """Create or return a local account, without setting a password.
 
     Carries no OIDC subject, so enabling Authentik later cannot collide with it:
-    `upsert_oidc_user` only ever matches rows by `oidc_sub`.
+    `upsert_oidc_user` only ever matches rows by `oidc_sub`. An account left
+    without a password cannot be signed into; `set_user_password` completes it.
     """
     with get_db() as conn:
         cursor = conn.cursor()
@@ -293,6 +298,95 @@ def ensure_local_user(username: str, *, is_admin: bool = True) -> Dict[str, Any]
         )
         conn.commit()
         return get_user(username)
+
+
+def local_account_exists() -> bool:
+    """True once any account has a password set.
+
+    Drives first-run setup: while this is False in local mode, the instance has
+    no way for anyone to sign in, so the setup page is open. Once it is True the
+    setup page closes permanently.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT 1 FROM users WHERE password_hash IS NOT NULL "
+            "AND password_hash != '' LIMIT 1"
+        )
+        return cursor.fetchone() is not None
+
+
+def sole_passwordless_username() -> Optional[str]:
+    """Username of the only account, when it has no password yet.
+
+    Identifies the implicit account that AUTH_MODE=none used to seed, so setup
+    can offer its name. Job and upload ownership is recorded as the username
+    string rather than the row id, so keeping that name is what keeps the
+    history attached — renaming the row would orphan it. Returns None as soon
+    as there is more than one account, since then there is nothing obvious to
+    adopt.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT username, password_hash FROM users LIMIT 2')
+        rows = cursor.fetchall()
+        if len(rows) != 1 or rows[0]['password_hash']:
+            return None
+        return rows[0]['username']
+
+
+def claim_first_local_admin(username: str, password_hash: str) -> Optional[Dict[str, Any]]:
+    """Create the first password account, or adopt a passwordless one.
+
+    Returns None if another request got there first. The guard and the write
+    share one transaction and the check is re-run inside it, so two concurrent
+    setup submissions cannot both succeed — whoever loses gets None rather than
+    silently overwriting the winner's password.
+
+    Adoption matters for instances upgrading from AUTH_MODE=none: that mode
+    seeded a passwordless row, and every job and upload records ownership
+    against its username. Reusing the row keeps that history attached to the
+    account instead of orphaning it under a new name.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute('BEGIN IMMEDIATE')
+        cursor.execute(
+            "SELECT 1 FROM users WHERE password_hash IS NOT NULL "
+            "AND password_hash != '' LIMIT 1"
+        )
+        if cursor.fetchone() is not None:
+            conn.rollback()
+            return None
+
+        cursor.execute('SELECT id FROM users WHERE username = ?', (username,))
+        row = cursor.fetchone()
+        if row:
+            cursor.execute(
+                'UPDATE users SET password_hash = ?, is_admin = 1 WHERE id = ?',
+                (password_hash, row['id']),
+            )
+        else:
+            cursor.execute(
+                '''INSERT INTO users (username, oidc_sub, email, name, avatar_url,
+                                      is_admin, password_hash)
+                   VALUES (?, NULL, NULL, ?, NULL, 1, ?)''',
+                (username, username, password_hash),
+            )
+        conn.commit()
+        return get_user(username)
+
+
+def set_user_password(username: str, password_hash: str) -> bool:
+    """Store a new password hash for an existing account."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            'UPDATE users SET password_hash = ? WHERE username = ?',
+            (password_hash, username),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
 
 
 def get_user(username: str) -> Optional[Dict[str, Any]]:

--- a/ui/frontend/src/components/app-sidebar.tsx
+++ b/ui/frontend/src/components/app-sidebar.tsx
@@ -91,16 +91,12 @@ export function AppSidebar() {
                 <Moon className="size-4" />
               )}
             </Button>
-            {!session?.auth_disabled && (
-              <>
-                <Separator orientation="vertical" className="h-5" />
-                <a href="/logout" aria-label="Log out">
-                  <Button variant="ghost" size="icon" title="Logout">
-                    <LogOut className="size-4" />
-                  </Button>
-                </a>
-              </>
-            )}
+            <Separator orientation="vertical" className="h-5" />
+            <a href="/logout" aria-label="Log out">
+              <Button variant="ghost" size="icon" title="Logout">
+                <LogOut className="size-4" />
+              </Button>
+            </a>
           </div>
           {session && (
             <div className="flex items-center gap-1.5 px-3 pb-2 text-xs text-muted-foreground">

--- a/ui/frontend/src/lib/api.ts
+++ b/ui/frontend/src/lib/api.ts
@@ -17,9 +17,9 @@ export class ApiError extends Error {
 
 async function request<T>(
   path: string,
-  init?: RequestInit & { json?: unknown },
+  init?: RequestInit & { json?: unknown; handle401?: boolean },
 ): Promise<T> {
-  const { json, ...rest } = init ?? {}
+  const { json, handle401, ...rest } = init ?? {}
   const res = await fetch(path, {
     credentials: 'same-origin',
     ...rest,
@@ -30,7 +30,10 @@ async function request<T>(
     body: json !== undefined ? JSON.stringify(json) : rest.body,
   })
 
-  if (res.status === 401) {
+  // handle401 opts out of the redirect. The sign-in call needs to: a 401 there
+  // means the password was wrong, and bouncing to /login would reload the page
+  // and discard the message explaining why.
+  if (res.status === 401 && !handle401) {
     // Session expired / not logged in → let the server-rendered login take over
     window.location.href = '/login'
     throw new ApiError(401, 'Not authenticated')
@@ -256,5 +259,19 @@ export const api = {
 
   // ===== Auth =====
   authStatus: () =>
-    request<{ sso_enabled: boolean; auth_disabled: boolean }>('/api/auth/status'),
+    request<{
+      auth_mode: 'local' | 'authentik'
+      local_auth_enabled: boolean
+      sso_enabled: boolean
+      setup_required: boolean
+      mobile_auth_enabled: boolean
+      auth_disabled: boolean
+    }>('/api/auth/status'),
+
+  localLogin: (username: string, password: string) =>
+    request<{ user: string; is_admin: boolean }>('/auth/local/login', {
+      method: 'POST',
+      json: { username, password },
+      handle401: true,
+    }),
 }

--- a/ui/frontend/src/pages/login-page.tsx
+++ b/ui/frontend/src/pages/login-page.tsx
@@ -4,6 +4,7 @@ import { ChefHat, Download, TriangleAlert } from 'lucide-react'
 import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<{ outcome: 'accepted' | 'dismissed' }>
@@ -47,6 +48,75 @@ function useInstallPrompt() {
   return { showInstall, install }
 }
 
+function PasswordForm() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      await api.localLogin(username, password)
+      // Full reload rather than client-side navigation: the session cookie is
+      // new, and every cached query was populated while signed out.
+      window.location.href = '/'
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign-in failed.')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {error && (
+        <div
+          role="alert"
+          className="flex gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2.5 text-sm text-destructive dark:border-destructive/30 dark:bg-destructive/20"
+        >
+          <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="username" className="text-sm font-medium text-foreground">
+          Username
+        </label>
+        <Input
+          id="username"
+          name="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          autoComplete="username"
+          autoCapitalize="none"
+          spellCheck={false}
+          required
+          autoFocus
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="password" className="text-sm font-medium text-foreground">
+          Password
+        </label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="current-password"
+          required
+        />
+      </div>
+      <Button type="submit" size="lg" className="w-full" disabled={submitting}>
+        {submitting ? 'Signing in…' : 'Sign in'}
+      </Button>
+    </form>
+  )
+}
+
 export function LoginPage() {
   const { data, isLoading } = useQuery({
     queryKey: ['authStatus'],
@@ -57,6 +127,15 @@ export function LoginPage() {
   const { showInstall, install } = useInstallPrompt()
 
   const ssoEnabled = data?.sso_enabled ?? true
+  const localAuth = data?.local_auth_enabled ?? false
+
+  // A fresh instance has no account yet; the server-rendered setup page is the
+  // only thing that can create one.
+  useEffect(() => {
+    if (data?.setup_required) {
+      window.location.href = '/setup'
+    }
+  }, [data?.setup_required])
 
   return (
     <div className="flex min-h-svh items-center justify-center bg-background p-4">
@@ -79,6 +158,8 @@ export function LoginPage() {
           <CardContent className="flex flex-col gap-3 pt-4">
             {isLoading ? (
               <div className="h-9 w-full animate-pulse rounded-lg bg-muted" />
+            ) : localAuth ? (
+              <PasswordForm />
             ) : ssoEnabled ? (
               <Button asChild size="lg" className="w-full">
                 <a href="/auth/login">Sign in with Authentik</a>
@@ -98,11 +179,11 @@ export function LoginPage() {
                   <code className="rounded bg-destructive/15 px-1 font-mono text-xs">
                     AUTHENTIK_CLIENT_SECRET
                   </code>
-                  , or set{' '}
+                  , or drop{' '}
                   <code className="rounded bg-destructive/15 px-1 font-mono text-xs">
-                    AUTH_MODE=none
+                    AUTH_MODE
                   </code>{' '}
-                  to run without authentication.
+                  to use local accounts instead.
                 </span>
               </div>
             )}

--- a/ui/frontend/src/types.ts
+++ b/ui/frontend/src/types.ts
@@ -292,7 +292,8 @@ export interface SettingsExport {
 export interface SessionUser {
   user: string
   is_admin: boolean
-  /** True when the server runs with AUTH_MODE=none, where logout is a no-op */
+  auth_mode?: 'local' | 'authentik'
+  /** Always false now; kept so an older cached bundle still parses a response. */
   auth_disabled?: boolean
   /** Popped server-side from the /share flow; consumed once by Home */
   shared_url?: string | null

--- a/ui/login_throttle.py
+++ b/ui/login_throttle.py
@@ -1,0 +1,72 @@
+"""Progressive backoff for failed sign-in attempts.
+
+Held in memory: this app runs as a single process, and a restart clearing the
+counters is an acceptable trade for having no external dependency. Attackers
+cannot trigger restarts, so the window this opens is not theirs to exploit.
+
+Deliberately not a lockout. An attacker who knows a username could otherwise
+lock its owner out at will, turning a brute-force defence into a denial of
+service. Attempts are slowed instead, and the delay decays on its own.
+"""
+
+import threading
+import time
+
+# Free attempts before any delay, then the delay doubles per failure. Reaching
+# the cap takes a handful of wrong guesses; sustained guessing settles at one
+# attempt per _MAX_DELAY, which makes an online attack useless without ever
+# denying the real owner access for long.
+_FREE_ATTEMPTS = 3
+_BASE_DELAY = 2.0
+_MAX_DELAY = 60.0
+
+# Failures older than this are forgotten, so a legitimate user who mistyped
+# their password an hour ago starts clean.
+_WINDOW = 900.0
+
+_lock = threading.Lock()
+_failures: dict[str, tuple[int, float]] = {}
+
+
+def _prune(now: float) -> None:
+    """Drop stale entries. Called under _lock."""
+    for key, (_, last_seen) in list(_failures.items()):
+        if now - last_seen > _WINDOW:
+            del _failures[key]
+
+
+def retry_after(key: str) -> float:
+    """Seconds the caller must wait before another attempt, or 0.0 if clear."""
+    now = time.monotonic()
+    with _lock:
+        _prune(now)
+        entry = _failures.get(key)
+        if entry is None:
+            return 0.0
+        count, last_seen = entry
+        if count <= _FREE_ATTEMPTS:
+            return 0.0
+        delay = min(_BASE_DELAY * (2 ** (count - _FREE_ATTEMPTS - 1)), _MAX_DELAY)
+        remaining = delay - (now - last_seen)
+        return max(0.0, remaining)
+
+
+def record_failure(key: str) -> None:
+    """Count a failed attempt against a key."""
+    now = time.monotonic()
+    with _lock:
+        _prune(now)
+        count, _ = _failures.get(key, (0, now))
+        _failures[key] = (count + 1, now)
+
+
+def reset(key: str) -> None:
+    """Forget a key's failures, after a successful sign-in."""
+    with _lock:
+        _failures.pop(key, None)
+
+
+def clear_all() -> None:
+    """Wipe all counters. For tests."""
+    with _lock:
+        _failures.clear()

--- a/ui/passwords.py
+++ b/ui/passwords.py
@@ -1,0 +1,88 @@
+"""Password hashing for local accounts.
+
+Argon2id, via argon2-cffi. Parameters are the library's defaults, which track
+the RFC 9106 guidance; they are recorded inside each hash, so raising them
+later does not invalidate existing passwords. Verification detects an outdated
+hash and callers re-store it (see needs_rehash).
+"""
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerifyMismatchError, VerificationError
+
+# Argon2id is the default type. Memory-hard, so a stolen database resists
+# GPU-driven guessing far better than a fast hash would.
+_hasher = PasswordHasher()
+
+# NIST SP 800-63B: length is what matters. No composition rules, and a ceiling
+# only so an enormous input cannot be used to burn CPU.
+MIN_PASSWORD_LENGTH = 10
+MAX_PASSWORD_LENGTH = 1024
+
+
+class WeakPassword(ValueError):
+    """Raised when a password fails the length policy."""
+
+
+def validate(password: str) -> None:
+    """Raise WeakPassword unless the password is an acceptable length.
+
+    Deliberately not a strength meter: character-class rules push people
+    towards predictable substitutions without adding real entropy.
+    """
+    if not isinstance(password, str) or not password:
+        raise WeakPassword('Enter a password.')
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise WeakPassword(
+            f'Password must be at least {MIN_PASSWORD_LENGTH} characters.'
+        )
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise WeakPassword(
+            f'Password must be at most {MAX_PASSWORD_LENGTH} characters.'
+        )
+
+
+def hash_password(password: str) -> str:
+    """Hash a password for storage. Salt is generated per call and embedded."""
+    validate(password)
+    return _hasher.hash(password)
+
+
+def verify(stored_hash: str | None, password: str) -> bool:
+    """Check a password against a stored hash, in constant time.
+
+    False for every failure mode — wrong password, malformed hash, or a user
+    with no password set — so callers cannot accidentally distinguish them and
+    leak which accounts exist.
+    """
+    if not stored_hash or not isinstance(password, str) or not password:
+        return False
+    try:
+        return _hasher.verify(stored_hash, password)
+    except (VerifyMismatchError, VerificationError, InvalidHashError):
+        return False
+
+
+def needs_rehash(stored_hash: str) -> bool:
+    """True when a hash predates the current cost parameters."""
+    try:
+        return _hasher.check_needs_rehash(stored_hash)
+    except (InvalidHashError, VerificationError):
+        return False
+
+
+def dummy_verify() -> None:
+    """Burn roughly the time a real verification takes.
+
+    Called on the no-such-user path so that a missing account and a wrong
+    password take comparable time. Without it, response latency alone
+    enumerates valid usernames.
+    """
+    try:
+        _hasher.verify(_DUMMY_HASH, 'not-the-password')
+    except (VerifyMismatchError, VerificationError, InvalidHashError):
+        pass
+
+
+# Computed once at import: hashing here would add startup cost on every boot,
+# and the value is not a secret — it is a hash of a fixed throwaway string.
+_DUMMY_HASH = _hasher.hash('timing-equalisation-placeholder')

--- a/ui/templates/login.html
+++ b/ui/templates/login.html
@@ -11,7 +11,23 @@
             <p>Extract recipes from social media videos</p>
         </div>
 
-        {% if sso_enabled %}
+        {% if local_auth %}
+        <form method="post" action="{{ url_for('auth_local_login') }}" class="login-form">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" autocomplete="username"
+                       autocapitalize="none" spellcheck="false" required autofocus>
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password"
+                       autocomplete="current-password" required>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">
+                <i class="fas fa-right-to-bracket"></i> Sign in
+            </button>
+        </form>
+        {% elif sso_enabled %}
         <a href="{{ url_for('auth_login') }}" class="btn btn-primary btn-block" style="display:flex; align-items:center; justify-content:center; gap:0.5rem;">
             <i class="fas fa-fingerprint"></i> Sign in with Authentik
         </a>
@@ -20,7 +36,7 @@
             <i class="fas fa-triangle-exclamation"></i>
             Single sign-on is not configured on this server. Set
             <code>AUTHENTIK_CLIENT_ID</code> and <code>AUTHENTIK_CLIENT_SECRET</code>,
-            or set <code>AUTH_MODE=none</code> to run without authentication.
+            or drop <code>AUTH_MODE</code> to use local accounts instead.
         </p>
         {% endif %}
 

--- a/ui/templates/setup.html
+++ b/ui/templates/setup.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block title %}Set up - Pick-a-Recipe{% endblock %}
+
+{% block content %}
+<div class="login-container">
+    <div class="login-card">
+        <div class="login-header">
+            <img src="{{ url_for('static', filename='icons/icon-192x192.png') }}" alt="Pick-a-Recipe" class="logo-image">
+            <h1>Welcome</h1>
+            <p>Create the administrator account for this instance</p>
+        </div>
+
+        {% if error %}
+        <p class="form-hint" style="text-align:center; color:var(--color-danger, #b00020);">
+            <i class="fas fa-triangle-exclamation"></i> {{ error }}
+        </p>
+        {% endif %}
+
+        <form method="post" action="{{ url_for('setup') }}" class="login-form">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" autocomplete="username"
+                       autocapitalize="none" spellcheck="false"
+                       value="{{ suggested_username }}" required autofocus>
+                {% if adopting %}
+                <small class="form-hint">This instance already has recipes saved
+                    under <strong>{{ adopting }}</strong>. Keep that name to carry
+                    them over; a different one starts with an empty history.</small>
+                {% endif %}
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password"
+                       autocomplete="new-password" minlength="10" required>
+                <small class="form-hint">At least 10 characters. Length matters more
+                    than symbols, so a memorable phrase works well.</small>
+            </div>
+            <div class="form-group">
+                <label for="confirm_password">Confirm password</label>
+                <input type="password" id="confirm_password" name="confirm_password"
+                       autocomplete="new-password" minlength="10" required>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">
+                <i class="fas fa-user-shield"></i> Create account
+            </button>
+        </form>
+
+        <p class="form-hint" style="text-align:center; margin-top:1rem;">
+            This page closes as soon as an account exists. If you did not open it
+            yourself, create the account now to stop someone else claiming it.
+        </p>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Why

This repo is public, so people run it without an Authentik instance. The only
answer to that was `AUTH_MODE=none`, which turned authentication off entirely.
Settings holds the LLM, Mealie and Tandoor API keys, so an instance in that mode
hands those to anyone who can reach the port — the escape hatch for "no identity
provider" and the escape hatch for "no access control" were the same switch.

This splits them: local accounts stored by the app, so a fresh container is
usable with no configuration and still not open.

## What changed

`AUTH_MODE` is now `local` (default) or `authentik`. There is no mode in which
authentication is off.

**First run.** A fresh instance in local mode has no account anyone can sign in
to, so every page redirects to `/setup`. It closes permanently once an account
exists, so it cannot be used to add a second admin or reset the first one's
password. Server-rendered, because it has to work before the frontend bundle is
necessarily built.

**Passwords.** Argon2id with a per-account salt, rehashed on login if cost
parameters are ever raised. Minimum 10 characters and no composition rules:
length is what resists guessing, while forced symbols mostly produce predictable
substitutions.

**Failed sign-ins** are delayed progressively per (IP, username) rather than
locking the account — locking would let anyone who knows a username lock its
owner out at will. Unknown username and wrong password return the same message
in comparable time, so the form cannot be used to enumerate accounts.

**In `authentik` mode** password sign-in is refused outright, so a row that
happens to carry a password cannot be used to go around SSO.

## Migrating from `AUTH_MODE=none`

Instances still setting it boot with a warning and run as `local`, landing on
setup. That mode seeded a passwordless account, and ownership of jobs and
uploads is recorded as the username *string*, not the row id — so setup offers
that existing name and reuses the row. Accepting the form as presented keeps the
history attached; typing a different name starts empty, and the page says so.

## Also fixes

`_migrate_schema` dropped the whole `users` table whenever `password_hash` was
present, left over from when local accounts were being retired in favour of
OIDC-only auth. It runs on every boot, so reintroducing that column without
removing this would have wiped accounts on restart and orphaned every job.
Replaced with an additive `ALTER TABLE`.

## Testing

130 tests pass. `AUTH_MODE` is read once at import, so each mode is exercised in
its own subprocess via a new `tests/app_harness.py`; `tests/test_local_auth.py`
covers setup, the concurrent-claim race, adoption, login, rehash-on-login,
throttling and status. Frontend lints and builds clean. Also smoke-tested by
hand end to end: weak password rejected, account created, session established,
throttle engaged and then decayed.

## Deliberately not here

The React setup page (the server template covers it), admin user management, and
mobile password sign-in. Follow-ups.

Made with [Cursor](https://cursor.com)