### PR TITLE
feat(ui): first-run setup in the SPA

### DIFF
--- a/tests/test_local_auth.py
+++ b/tests/test_local_auth.py
@@ -26,6 +26,7 @@ GOOD_PASSWORD = 'a properly long passphrase'
 # Prelude shared by the forked scripts: local mode, an empty users table, and a
 # helper that creates the first account without going through the HTTP flow.
 _PRELUDE = f"""
+    import os
     import database, login_throttle, passwords
     from app import app
 
@@ -96,8 +97,29 @@ class TestFirstRunSetup(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.res = _run_local("""
+            import app as app_module
+
+            # This class covers the server-rendered fallback, so point the app
+            # at a bundle that is not there. Otherwise whether these assertions
+            # see a Jinja form or the SPA shell would depend on whether someone
+            # had run `npm run build` before pytest.
+            spa_dist = app_module.FRONTEND_DIST
+            app_module.FRONTEND_DIST = '/nonexistent-frontend-dist'
+
             client = app.test_client()
             page = client.get('/setup')
+
+            # With a bundle present the SPA takes over, and its /setup route
+            # drives the same endpoints.
+            app_module.FRONTEND_DIST = spa_dist
+            spa_page = app.test_client().get('/setup')
+            spa_served = (
+                spa_page.status_code == 200
+                and b'Create account' not in spa_page.data
+                if os.path.exists(os.path.join(spa_dist, 'index.html'))
+                else None
+            )
+            app_module.FRONTEND_DIST = '/nonexistent-frontend-dist'
 
             created = client.post('/setup', data={
                 'username': 'chef',
@@ -119,6 +141,7 @@ class TestFirstRunSetup(unittest.TestCase):
             emit(
                 page_status=page.status_code,
                 page_has_form=b'Create account' in page.data,
+                spa_served=spa_served,
                 created_status=created.status_code,
                 row_is_admin=bool(row and row['is_admin']),
                 row_hash_is_argon2id=(row or {}).get(
@@ -132,8 +155,15 @@ class TestFirstRunSetup(unittest.TestCase):
         """)
 
     def test_setup_page_served_while_no_account_exists(self):
+        """A source checkout with no built bundle still has to be set up."""
         self.assertEqual(self.res['page_status'], 200)
         self.assertTrue(self.res['page_has_form'])
+
+    def test_built_bundle_takes_over_the_page(self):
+        served = self.res['spa_served']
+        if served is None:
+            self.skipTest('no frontend bundle built in this checkout')
+        self.assertTrue(served)
 
     def test_setup_creates_an_admin(self):
         self.assertEqual(self.res['created_status'], 302)
@@ -199,6 +229,74 @@ class TestSetupValidation(unittest.TestCase):
         self._assert_rejected(self.res['long_user'])
 
 
+class TestJsonSetupEndpoint(unittest.TestCase):
+    """/api/setup, the SPA's route into a fresh instance."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            database.ensure_local_user('local')  # an AUTH_MODE=none leftover
+
+            info = app.test_client().get('/api/setup')
+
+            short = app.test_client().post(
+                '/api/setup',
+                json={'username': 'chef', 'password': 'abc',
+                      'confirm_password': 'abc'},
+            )
+
+            client = app.test_client()
+            created = client.post(
+                '/api/setup',
+                json={'username': 'local', 'password': GOOD_PASSWORD,
+                      'confirm_password': GOOD_PASSWORD},
+            )
+            authed_after = client.get('/api/me').status_code
+
+            # A tab left open on the setup page after someone else finished.
+            stale_get = app.test_client().get('/api/setup')
+            stale_post = app.test_client().post(
+                '/api/setup',
+                json={'username': 'usurper', 'password': GOOD_PASSWORD,
+                      'confirm_password': GOOD_PASSWORD},
+            )
+
+            emit(
+                info_status=info.status_code,
+                info_body=info.get_json(),
+                short_status=short.status_code,
+                short_error=(short.get_json() or {}).get('error', ''),
+                created_status=created.status_code,
+                created_body=created.get_json(),
+                authed_after=authed_after,
+                stale_get_status=stale_get.status_code,
+                stale_post_status=stale_post.status_code,
+                usurper_exists=database.get_user('usurper') is not None,
+            )
+        """)
+
+    def test_info_reports_the_adoptable_account(self):
+        self.assertEqual(self.res['info_status'], 200)
+        self.assertEqual(self.res['info_body']['suggested_username'], 'local')
+        self.assertEqual(self.res['info_body']['adopting'], 'local')
+
+    def test_validation_matches_the_form(self):
+        self.assertEqual(self.res['short_status'], 400)
+        self.assertIn('at least', self.res['short_error'])
+
+    def test_creating_the_account_signs_it_in(self):
+        self.assertEqual(self.res['created_status'], 200)
+        self.assertEqual(self.res['created_body']['user'], 'local')
+        self.assertTrue(self.res['created_body']['is_admin'])
+        self.assertEqual(self.res['authed_after'], 200)
+
+    def test_endpoint_closes_once_an_account_exists(self):
+        """409 rather than 404, so a stale tab can tell why and go to /login."""
+        self.assertEqual(self.res['stale_get_status'], 409)
+        self.assertEqual(self.res['stale_post_status'], 409)
+        self.assertFalse(self.res['usurper_exists'])
+
+
 class TestSetupRaceAndAdoption(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -217,11 +315,6 @@ class TestSetupRaceAndAdoption(unittest.TestCase):
             # no password, and every job recorded ownership against its name.
             database.ensure_local_user('local')
             needs_setup_with_passwordless_row = database.local_account_exists()
-
-            # The name the setup form offers. It has to be the existing one, or
-            # the obvious path through the form orphans that account's history.
-            suggested = app.test_client().get('/setup').get_data(as_text=True)
-
             adopted = make_admin('local')
             row = database.get_user('local')
             with database.get_db() as conn:
@@ -232,7 +325,6 @@ class TestSetupRaceAndAdoption(unittest.TestCase):
                 second_claimed=second is not None,
                 second_row_exists=database.get_user('second') is not None,
                 needs_setup_with_passwordless_row=needs_setup_with_passwordless_row,
-                setup_page_offers_existing_name='value="local"' in suggested,
                 adopted=adopted is not None,
                 adopted_has_password=bool(row and row['password_hash']),
                 adopted_is_admin=bool(row and row['is_admin']),
@@ -257,17 +349,13 @@ class TestSetupRaceAndAdoption(unittest.TestCase):
         self.assertTrue(self.res['adopted_oidc_sub_is_null'])
 
     def test_adoption_reuses_the_row_rather_than_adding_one(self):
-        """A new username would orphan the history owned by the old one."""
-        self.assertEqual(self.res['user_count'], 1)
+        """A new username would orphan the history owned by the old one.
 
-    def test_setup_offers_the_adoptable_username(self):
-        """Ownership is stored as the username, so adoption hinges on the name.
-
-        The default suggestion is 'admin', which would not match the 'local'
-        that AUTH_MODE=none seeded — accepting the form as presented has to keep
-        the history rather than silently stranding it.
+        Which is why the name matters: TestJsonSetupEndpoint asserts the setup
+        page offers the adoptable one rather than the 'admin' default, so the
+        obvious path through the form lands here.
         """
-        self.assertTrue(self.res['setup_page_offers_existing_name'])
+        self.assertEqual(self.res['user_count'], 1)
 
 
 class TestLocalLogin(unittest.TestCase):

--- a/ui/app.py
+++ b/ui/app.py
@@ -571,27 +571,52 @@ def login():
     )
 
 
+def _adoptable_username() -> str | None:
+    """The account first-run setup should offer to take over, if there is one.
+
+    An instance upgrading from AUTH_MODE=none already owns jobs and uploads under
+    the name that mode seeded, and ownership is recorded as the username rather
+    than the row id. Offering that name means the obvious path through the form
+    keeps the history; typing a different one starts fresh.
+    """
+    return sole_passwordless_username()
+
+
+def _validate_new_account(username: str, password: str, confirm: str) -> str | None:
+    """Reason the proposed first account is unacceptable, or None if it is fine."""
+    if not username:
+        return 'Choose a username.'
+    if len(username) > 64:
+        return 'Username must be at most 64 characters.'
+    if password != confirm:
+        return 'The two passwords do not match.'
+    try:
+        passwords.validate(password)
+    except passwords.WeakPassword as exc:
+        return str(exc)
+    return None
+
+
 @app.route('/setup', methods=['GET', 'POST'])
 def setup():
     """Create the first account, while the instance has none.
 
-    Served from a template rather than the SPA on purpose: this has to work
-    before the frontend bundle is necessarily built, and it is the only way
-    into a fresh instance.
+    Falls back to a server-rendered form when no frontend bundle is present, so
+    a source checkout without a `npm run build` can still be set up — this is
+    the only way into a fresh instance.
     """
     if not _setup_required():
         # Closed for good once an account exists, so this cannot be used to
         # add a second admin or overwrite the first one's password.
         return redirect(url_for('login'))
 
-    # An instance upgrading from AUTH_MODE=none already owns jobs and uploads
-    # under the name that mode seeded, and ownership is recorded as the username
-    # rather than the row id. Offering that name means the obvious path through
-    # this form keeps the history; typing a different one starts fresh.
-    adoptable = sole_passwordless_username()
+    adoptable = _adoptable_username()
     suggested = adoptable or LOCAL_USERNAME
 
     if request.method == 'GET':
+        spa = os.path.join(FRONTEND_DIST, 'index.html')
+        if os.path.exists(spa):
+            return send_from_directory(FRONTEND_DIST, 'index.html')
         return render_template(
             'setup.html', suggested_username=suggested, adopting=adoptable
         )
@@ -600,19 +625,7 @@ def setup():
     password = request.form.get('password') or ''
     confirm = request.form.get('confirm_password') or ''
 
-    error = None
-    if not username:
-        error = 'Choose a username.'
-    elif len(username) > 64:
-        error = 'Username must be at most 64 characters.'
-    elif password != confirm:
-        error = 'The two passwords do not match.'
-    else:
-        try:
-            passwords.validate(password)
-        except passwords.WeakPassword as exc:
-            error = str(exc)
-
+    error = _validate_new_account(username, password, confirm)
     if error:
         return render_template(
             'setup.html',
@@ -629,6 +642,44 @@ def setup():
     print(f"[Auth] first account created: {user['username']}")
     _establish_session(user['username'], is_admin=True)
     return redirect(url_for('index'))
+
+
+@app.route('/api/setup', methods=['GET', 'POST'])
+def api_setup():
+    """JSON counterpart of /setup, for the SPA.
+
+    Unauthenticated by necessity — it exists precisely because no account does
+    yet — but it stops answering the moment one exists, so it is not a way to
+    read or change an established instance.
+    """
+    if not _setup_required():
+        return jsonify({'error': 'Setup has already been completed.'}), 409
+
+    if request.method == 'GET':
+        adoptable = _adoptable_username()
+        return jsonify({
+            'suggested_username': adoptable or LOCAL_USERNAME,
+            # Named so the client can say what carrying the name over means.
+            'adopting': adoptable,
+        })
+
+    payload = request.get_json(silent=True)
+    source = payload if isinstance(payload, dict) else request.form
+    username = str(source.get('username') or '').strip()
+    password = str(source.get('password') or '')
+    confirm = str(source.get('confirm_password') or '')
+
+    error = _validate_new_account(username, password, confirm)
+    if error:
+        return jsonify({'error': error}), 400
+
+    user = claim_first_local_admin(username, passwords.hash_password(password))
+    if user is None:
+        return jsonify({'error': 'Setup has already been completed.'}), 409
+
+    print(f"[Auth] first account created: {user['username']}")
+    _establish_session(user['username'], is_admin=True)
+    return jsonify({'user': user['username'], 'is_admin': True})
 
 
 @app.route('/auth/local/login', methods=['POST'])

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { AppShell } from '@/components/app-shell'
 import { Toaster } from '@/components/ui/sonner'
 import { LoginPage } from '@/pages/login-page'
+import { SetupPage } from '@/pages/setup-page'
 import { HomePage } from '@/pages/home-page'
 import { JobPage } from '@/pages/job-page'
 import { TasksPage } from '@/pages/tasks-page'
@@ -26,6 +27,8 @@ export default function App() {
           <Routes>
             {/* Login is a bare page — Flask handles the actual OIDC redirect */}
             <Route path="/login" element={<LoginPage />} />
+            {/* Bare too: no shell, since there is no session to render one for */}
+            <Route path="/setup" element={<SetupPage />} />
             <Route element={<AppShell />}>
               <Route path="/" element={<HomePage />} />
               <Route path="/jobs/:jobId" element={<JobPage />} />

--- a/ui/frontend/src/lib/api.ts
+++ b/ui/frontend/src/lib/api.ts
@@ -274,4 +274,19 @@ export const api = {
       json: { username, password },
       handle401: true,
     }),
+
+  // ===== First-run setup =====
+  // Only answers while the instance has no account; 409 once one exists.
+  setupInfo: () =>
+    request<{ suggested_username: string; adopting: string | null }>('/api/setup'),
+
+  createFirstAccount: (
+    username: string,
+    password: string,
+    confirmPassword: string,
+  ) =>
+    request<{ user: string; is_admin: boolean }>('/api/setup', {
+      method: 'POST',
+      json: { username, password, confirm_password: confirmPassword },
+    }),
 }

--- a/ui/frontend/src/pages/login-page.tsx
+++ b/ui/frontend/src/pages/login-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ChefHat, Download, TriangleAlert } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -129,13 +130,10 @@ export function LoginPage() {
   const ssoEnabled = data?.sso_enabled ?? true
   const localAuth = data?.local_auth_enabled ?? false
 
-  // A fresh instance has no account yet; the server-rendered setup page is the
-  // only thing that can create one.
-  useEffect(() => {
-    if (data?.setup_required) {
-      window.location.href = '/setup'
-    }
-  }, [data?.setup_required])
+  // A fresh instance has no account yet, so there is nothing to sign in to.
+  if (data?.setup_required) {
+    return <Navigate to="/setup" replace />
+  }
 
   return (
     <div className="flex min-h-svh items-center justify-center bg-background p-4">

--- a/ui/frontend/src/pages/setup-page.tsx
+++ b/ui/frontend/src/pages/setup-page.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ChefHat, ShieldCheck, TriangleAlert } from 'lucide-react'
+import { api, ApiError } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+/**
+ * First-run account creation.
+ *
+ * Reachable only while the instance has no account. The server closes the
+ * endpoint the moment one exists, so a stale tab left on this page gets a 409
+ * rather than a second admin.
+ */
+export function SetupPage() {
+  const { data, isLoading, error: loadError } = useQuery({
+    queryKey: ['setupInfo'],
+    queryFn: api.setupInfo,
+    retry: false,
+  })
+
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Null until the user types, so the server's suggestion can show through
+  // without an effect copying it into state. Clearing the field keeps it empty
+  // ('' is not null) rather than springing back to the suggestion.
+  const [typedUsername, setTypedUsername] = useState<string | null>(null)
+  const username = typedUsername ?? data?.suggested_username ?? ''
+
+  // Somebody claimed the account while this page was open, or it was loaded on
+  // an instance that never needed setup.
+  const alreadySetUp = loadError instanceof ApiError && loadError.status === 409
+  useEffect(() => {
+    if (alreadySetUp) {
+      window.location.href = '/login'
+    }
+  }, [alreadySetUp])
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      await api.createFirstAccount(username, password, confirm)
+      // Full reload rather than client-side navigation: the session cookie is
+      // new, and every cached query was populated while signed out.
+      window.location.href = '/'
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        window.location.href = '/login'
+        return
+      }
+      setError(err instanceof Error ? err.message : 'Could not create the account.')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-svh items-center justify-center bg-background p-4">
+      <div className="flex w-full max-w-sm flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex size-16 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+            <ChefHat className="size-8" />
+          </div>
+          <div className="text-center">
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              Welcome
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Create the administrator account for this instance
+            </p>
+          </div>
+        </div>
+
+        <Card className="w-full">
+          <CardContent className="pt-4">
+            {isLoading || alreadySetUp ? (
+              <div className="flex flex-col gap-3">
+                <div className="h-9 w-full animate-pulse rounded-lg bg-muted" />
+                <div className="h-9 w-full animate-pulse rounded-lg bg-muted" />
+                <div className="h-9 w-full animate-pulse rounded-lg bg-muted" />
+              </div>
+            ) : (
+              <form onSubmit={onSubmit} className="flex flex-col gap-3">
+                {error && (
+                  <div
+                    role="alert"
+                    className="flex gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2.5 text-sm text-destructive dark:border-destructive/30 dark:bg-destructive/20"
+                  >
+                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                    <span>{error}</span>
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-1.5">
+                  <label
+                    htmlFor="username"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Username
+                  </label>
+                  <Input
+                    id="username"
+                    name="username"
+                    value={username}
+                    onChange={(e) => setTypedUsername(e.target.value)}
+                    autoComplete="username"
+                    autoCapitalize="none"
+                    spellCheck={false}
+                    required
+                    autoFocus
+                  />
+                  {data?.adopting && (
+                    <p className="text-xs text-muted-foreground">
+                      This instance already has recipes saved under{' '}
+                      <span className="font-medium text-foreground">
+                        {data.adopting}
+                      </span>
+                      . Keep that name to carry them over; a different one starts
+                      with an empty history.
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1.5">
+                  <label
+                    htmlFor="password"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Password
+                  </label>
+                  <Input
+                    id="password"
+                    name="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    autoComplete="new-password"
+                    minLength={10}
+                    required
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    At least 10 characters. Length matters more than symbols, so a
+                    memorable phrase works well.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-1.5">
+                  <label
+                    htmlFor="confirm_password"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Confirm password
+                  </label>
+                  <Input
+                    id="confirm_password"
+                    name="confirm_password"
+                    type="password"
+                    value={confirm}
+                    onChange={(e) => setConfirm(e.target.value)}
+                    autoComplete="new-password"
+                    minLength={10}
+                    required
+                  />
+                </div>
+
+                <Button
+                  type="submit"
+                  size="lg"
+                  className="w-full"
+                  disabled={submitting}
+                >
+                  <ShieldCheck />
+                  {submitting ? 'Creating account…' : 'Create account'}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+
+        <p className="max-w-sm text-center text-xs text-muted-foreground">
+          This page closes as soon as an account exists. If you did not open it
+          yourself, create the account now to stop someone else claiming it.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Follow-up to #22.

## Why

Setup is the one page every new user is guaranteed to see, and it was the only
one still rendered from the legacy Jinja templates. So the first impression of
the app was a screen that looks nothing like the app.

## What changed

A `/setup` route in the SPA, backed by a JSON `/api/setup`. Flask serves the
bundle for `/setup` when one is built, and falls back to the existing
server-rendered form otherwise — setup is the only way into a fresh instance, so
it must not depend on anyone having run `npm run build`.

`/api/setup` is unauthenticated by necessity: it exists precisely because no
account does yet. It stops answering with 409 the moment one exists, so a tab
left open on the setup page after someone else finished gets a 409 and is sent
to `/login` instead of being able to claim a second admin. Same guard as the
form route, same reason.

The adoptable-username hint moves across too. An instance upgrading from
`AUTH_MODE=none` has its jobs and uploads recorded against the username that
mode seeded, so the page offers that name and says that changing it starts with
an empty history.

`/login` now navigates to `/setup` client-side rather than assigning
`window.location`, since both are SPA routes.

## Testing

134 tests pass. New `TestJsonSetupEndpoint` covers the suggestion, validation
parity with the form, sign-in on creation, and the 409 once an account exists.
`TestFirstRunSetup` now pins `FRONTEND_DIST` explicitly so its assertions do not
silently change meaning depending on whether a bundle happened to be built, and
asserts the bundle takes over when there is one.

Smoke-tested over HTTP end to end on a fresh database: `/` → `/login` →
`/setup`, weak password and mismatch rejected, account created and signed in,
setup then closed with 409, `/setup` redirecting to `/login`, login with the new
password, and wrong-password and unknown-user returning the same message.

Made with [Cursor](https://cursor.com)