### PR TITLE
feat(auth): admin account management and admin-only settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,33 @@ which would let anyone who knows your username lock you out at will. Wrong
 password and no-such-user return the same message and take comparable time, so
 the login form cannot be used to discover which accounts exist.
 
+**Accounts and admins**
+
+The account created on the setup page is an admin. Admins see the whole settings
+page and manage accounts there; everyone else gets a sign-in and a password form.
+That split exists because settings holds your API keys, so an ordinary account
+should not be able to read them.
+
+Admins can add accounts, grant or revoke admin rights, set a password for someone
+who forgot theirs, and delete accounts. There is no self-registration: on a
+self-hosted instance, an open sign-up form is a way in for anyone who finds the
+URL. Two rules cannot be worked around, because either would leave the instance
+with no way back in: you cannot remove your own admin rights, and you cannot
+remove the last admin's.
+
+Deleting an account removes its queued and in-progress jobs and its pending
+uploads. Recipes that finished are left alone — they belong to the instance, and
+the person leaving is usually not the only one who cares about them. Deleting or
+demoting someone takes effect on their next request rather than whenever their
+cookie expires, so revoking access is immediate.
+
+Changing your own password requires your current one, so a borrowed session
+cannot be used to lock you out of your own account.
+
+In `authentik` mode this section does not apply: accounts, passwords and group
+membership live in Authentik, and the settings page says so instead of offering
+controls that could not work.
+
 **Upgrading from `AUTH_MODE=none`**
 
 That mode is gone; authentication can no longer be switched off. An instance

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -1,0 +1,539 @@
+"""Tests for admin user management, admin gating, and session revocation.
+
+Same forked-interpreter approach as test_local_auth: AUTH_MODE is fixed when
+`app` is imported, and other suites in this run need it left alone.
+"""
+
+import os
+import sys
+import textwrap
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'ui'))
+
+from app_harness import result as _result, run as _run  # noqa: E402
+
+PASSWORD = 'a properly long passphrase'
+OTHER_PASSWORD = 'another properly long phrase'
+
+# Gives each script an admin, a plain user, and signed-in clients for both.
+_PRELUDE = f"""
+    import database, login_throttle, passwords
+    from app import app
+
+    PASSWORD = {PASSWORD!r}
+    OTHER_PASSWORD = {OTHER_PASSWORD!r}
+    app.config['TESTING'] = True
+
+    def hashed(password=PASSWORD):
+        return passwords.hash_password(password)
+
+    def sign_in(username, password=PASSWORD):
+        client = app.test_client()
+        resp = client.post('/auth/local/login',
+                           json={{'username': username, 'password': password}})
+        assert resp.status_code == 200, (username, resp.status_code, resp.data)
+        return client
+
+    def seed():
+        database.claim_first_local_admin('boss', hashed())
+        database.create_local_user('cook', hashed(), is_admin=False)
+        return sign_in('boss'), sign_in('cook')
+"""
+
+
+def _run_local(script: str, **env) -> dict:
+    combined = textwrap.dedent(_PRELUDE) + textwrap.dedent(script)
+    return _result(_run(combined, **env))
+
+
+class TestConfigIsAdminOnly(unittest.TestCase):
+    """Settings holds the LLM, Mealie and Tandoor API keys.
+
+    Reading it is as sensitive as writing it, so a non-admin must not be able to
+    GET it either — that was the hole that made admin-created accounts unsafe.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            emit(
+                admin_get=admin.get('/api/config').status_code,
+                user_get=user.get('/api/config').status_code,
+                user_post=user.post('/api/config',
+                                    json={'recipe_language': 'de'}).status_code,
+                user_export=user.get('/api/settings/export').status_code,
+                user_import=user.post('/api/settings/import',
+                                      json={'settings': {}}).status_code,
+                user_cookies_delete=user.delete('/api/cookies/delete').status_code,
+                anon_get=app.test_client().get('/api/config').status_code,
+                # The keys must not have moved despite the attempt.
+                language_unchanged=database.load_config().get(
+                    'recipe_language') != 'de',
+            )
+        """)
+
+    def test_admin_can_read_config(self):
+        self.assertEqual(self.res['admin_get'], 200)
+
+    def test_non_admin_cannot_read_the_api_keys(self):
+        self.assertEqual(self.res['user_get'], 403)
+        self.assertEqual(self.res['user_export'], 403)
+
+    def test_non_admin_cannot_change_instance_config(self):
+        self.assertEqual(self.res['user_post'], 403)
+        self.assertEqual(self.res['user_import'], 403)
+        self.assertEqual(self.res['user_cookies_delete'], 403)
+        self.assertTrue(self.res['language_unchanged'])
+
+    def test_anonymous_gets_401_not_403(self):
+        """So a client can tell "sign in" from "you are not allowed"."""
+        self.assertEqual(self.res['anon_get'], 401)
+
+
+class TestListingAndCreating(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            listing = admin.get('/api/users')
+            body = listing.get_json()
+
+            created = admin.post('/api/users', json={
+                'username': 'baker', 'password': OTHER_PASSWORD, 'is_admin': True,
+            })
+            duplicate = admin.post('/api/users', json={
+                'username': 'baker', 'password': OTHER_PASSWORD,
+            })
+            weak = admin.post('/api/users', json={
+                'username': 'weakling', 'password': 'short',
+            })
+            nameless = admin.post('/api/users', json={
+                'username': '  ', 'password': OTHER_PASSWORD,
+            })
+            # No spaces, so this can only be rejected by the control-character
+            # check rather than incidentally by the whitespace one.
+            forged_log = admin.post('/api/users', json={
+                'username': 'mole\\nauth-INFO-account_deleted:boss',
+                'password': OTHER_PASSWORD,
+            })
+            tabbed = admin.post('/api/users', json={
+                'username': 'mole\\tboss', 'password': OTHER_PASSWORD,
+            })
+            spaced = admin.post('/api/users', json={
+                'username': 'two words', 'password': OTHER_PASSWORD,
+            })
+
+            by_user = user.post('/api/users', json={
+                'username': 'sneaky', 'password': OTHER_PASSWORD,
+            })
+
+            emit(
+                listing_status=listing.status_code,
+                usernames=[u['username'] for u in body['users']],
+                admin_count=body['admin_count'],
+                hashes_absent=all(
+                    'password_hash' not in u for u in body['users']),
+                has_password_flags={
+                    u['username']: u['has_password'] for u in body['users']},
+                listing_by_non_admin=user.get('/api/users').status_code,
+                created_status=created.status_code,
+                created_is_admin=created.get_json()['user']['is_admin'],
+                new_user_can_sign_in=app.test_client().post(
+                    '/auth/local/login',
+                    json={'username': 'baker', 'password': OTHER_PASSWORD},
+                ).status_code,
+                duplicate_status=duplicate.status_code,
+                weak_status=weak.status_code,
+                nameless_status=nameless.status_code,
+                forged_log_status=forged_log.status_code,
+                tabbed_status=tabbed.status_code,
+                spaced_status=spaced.status_code,
+                forged_account_absent=not any(
+                    'account_deleted' in u['username']
+                    for u in admin.get('/api/users').get_json()['users']),
+                by_user_status=by_user.status_code,
+                sneaky_exists=database.get_user('sneaky') is not None,
+            )
+        """)
+
+    def test_listing_shows_accounts_without_hashes(self):
+        self.assertEqual(self.res['listing_status'], 200)
+        self.assertEqual(sorted(self.res['usernames']), ['boss', 'cook'])
+        self.assertEqual(self.res['admin_count'], 1)
+        self.assertTrue(
+            self.res['hashes_absent'],
+            'the API must never hand out password hashes',
+        )
+        self.assertEqual(
+            self.res['has_password_flags'], {'boss': True, 'cook': True}
+        )
+
+    def test_only_admins_can_list(self):
+        self.assertEqual(self.res['listing_by_non_admin'], 403)
+
+    def test_admin_can_create_a_usable_account(self):
+        self.assertEqual(self.res['created_status'], 201)
+        self.assertTrue(self.res['created_is_admin'])
+        self.assertEqual(self.res['new_user_can_sign_in'], 200)
+
+    def test_duplicate_username_is_refused(self):
+        self.assertEqual(self.res['duplicate_status'], 409)
+
+    def test_weak_password_and_blank_name_refused(self):
+        self.assertEqual(self.res['weak_status'], 400)
+        self.assertEqual(self.res['nameless_status'], 400)
+
+    def test_control_characters_in_a_username_are_refused(self):
+        """A newline would let a created account forge account-audit entries."""
+        self.assertEqual(self.res['forged_log_status'], 400)
+        self.assertEqual(self.res['tabbed_status'], 400)
+        self.assertEqual(self.res['spaced_status'], 400)
+        self.assertTrue(self.res['forged_account_absent'])
+
+    def test_non_admin_cannot_create_accounts(self):
+        """No self-registration: the admin decides who exists."""
+        self.assertEqual(self.res['by_user_status'], 403)
+        self.assertFalse(self.res['sneaky_exists'])
+
+
+class TestAdminRightsGuards(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            promote = admin.patch('/api/users/cook', json={'is_admin': True})
+            cook_admin_after_promote = bool(
+                database.get_user('cook')['is_admin'])
+
+            # Two admins now, so demoting the other one is allowed...
+            demote_other = admin.patch('/api/users/cook',
+                                       json={'is_admin': False})
+            # ...but never yourself, and never the last one standing.
+            demote_self = admin.patch('/api/users/boss',
+                                      json={'is_admin': False})
+            boss_still_admin = bool(database.get_user('boss')['is_admin'])
+
+            missing = admin.patch('/api/users/ghost', json={'is_admin': True})
+
+            # Leave boss as the sole admin and have it try to demote itself
+            # through the last-admin guard rather than the self guard.
+            database.set_user_admin('cook', True)
+            database.set_user_admin('boss', False)
+            cook = sign_in('cook')
+            demote_last = cook.patch('/api/users/cook', json={'is_admin': False})
+
+            emit(
+                promote_status=promote.status_code,
+                cook_admin_after_promote=cook_admin_after_promote,
+                demote_other_status=demote_other.status_code,
+                demote_self_status=demote_self.status_code,
+                demote_self_error=(demote_self.get_json() or {}).get('error', ''),
+                boss_still_admin=boss_still_admin,
+                demote_last_status=demote_last.status_code,
+                missing_status=missing.status_code,
+            )
+        """)
+
+    def test_admin_can_promote_and_demote_others(self):
+        self.assertEqual(self.res['promote_status'], 200)
+        self.assertTrue(self.res['cook_admin_after_promote'])
+        self.assertEqual(self.res['demote_other_status'], 200)
+
+    def test_you_cannot_demote_yourself(self):
+        """You would lose the rights needed to undo it."""
+        self.assertEqual(self.res['demote_self_status'], 400)
+        self.assertIn('your own', self.res['demote_self_error'])
+        self.assertTrue(self.res['boss_still_admin'])
+
+    def test_the_last_admin_cannot_be_demoted(self):
+        self.assertEqual(self.res['demote_last_status'], 400)
+
+    def test_unknown_account_is_404(self):
+        self.assertEqual(self.res['missing_status'], 404)
+
+
+class TestDeletion(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            # Work owned by the account about to be deleted, plus a job whose
+            # pending upload predates ownership being recorded.
+            owned = database.create_job('https://example.com/a', user_id='cook')
+            legacy = database.create_job('https://example.com/b', user_id='cook')
+            keep = database.create_job('https://example.com/c', user_id='boss')
+            def upload(upload_id, job_id, owner):
+                database.create_pending_upload(
+                    upload_id, job_id, {'name': upload_id}, None, [], 'mealie',
+                    user_id=owner)
+
+            upload('up-owned', owned, 'cook')
+            upload('up-legacy', legacy, None)
+            upload('up-keep', keep, 'boss')
+            database.save_push_subscription('cook', 'https://p/1', 'k', 'a')
+
+            self_delete = admin.delete('/api/users/boss')
+            missing = admin.delete('/api/users/ghost')
+            by_user = user.delete('/api/users/boss')
+
+            deleted = admin.delete('/api/users/cook')
+            cook_gone = database.get_user('cook') is None
+
+            with database.get_db() as conn:
+                remaining_jobs = [
+                    r['id'] for r in conn.execute(
+                        'SELECT id FROM recipe_jobs').fetchall()]
+                remaining_uploads = [
+                    r['id'] for r in conn.execute(
+                        'SELECT id FROM pending_uploads').fetchall()]
+                push_left = conn.execute(
+                    'SELECT COUNT(*) FROM push_subscriptions '
+                    'WHERE username = ?', ('cook',)).fetchone()[0]
+
+            # Reusing the name must not inherit the previous holder's work.
+            database.create_local_user('cook', hashed(), is_admin=False)
+            reused = sign_in('cook')
+            inherited = reused.get('/api/jobs').get_json()
+
+            emit(
+                self_delete_status=self_delete.status_code,
+                self_delete_error=(self_delete.get_json() or {}).get('error', ''),
+                missing_status=missing.status_code,
+                by_user_status=by_user.status_code,
+                boss_survives=database.get_user('boss') is not None,
+                deleted_status=deleted.status_code,
+                cook_gone=cook_gone,
+                kept_job_present=keep in remaining_jobs,
+                owned_jobs_gone=owned not in remaining_jobs
+                                and legacy not in remaining_jobs,
+                kept_upload_present='up-keep' in remaining_uploads,
+                owned_uploads_gone='up-owned' not in remaining_uploads,
+                legacy_upload_gone='up-legacy' not in remaining_uploads,
+                push_left=push_left,
+                inherited_job_count=len(inherited.get('jobs', inherited)
+                                        if isinstance(inherited, dict)
+                                        else inherited),
+            )
+        """)
+
+    def test_you_cannot_delete_your_own_account(self):
+        self.assertEqual(self.res['self_delete_status'], 400)
+        self.assertIn('your own', self.res['self_delete_error'])
+        self.assertTrue(self.res['boss_survives'])
+
+    def test_unknown_account_and_non_admin_refused(self):
+        self.assertEqual(self.res['missing_status'], 404)
+        self.assertEqual(self.res['by_user_status'], 403)
+
+    def test_deleting_removes_the_account(self):
+        self.assertEqual(self.res['deleted_status'], 200)
+        self.assertTrue(self.res['cook_gone'])
+
+    def test_owned_work_goes_with_the_account(self):
+        """Ownership is the username string, so orphans would be inheritable."""
+        self.assertTrue(self.res['owned_jobs_gone'])
+        self.assertTrue(self.res['owned_uploads_gone'])
+        self.assertEqual(self.res['push_left'], 0)
+
+    def test_a_pending_upload_with_no_owner_follows_its_job(self):
+        """Rows from before ownership was recorded carry a NULL user_id."""
+        self.assertTrue(self.res['legacy_upload_gone'])
+
+    def test_other_accounts_are_untouched(self):
+        self.assertTrue(self.res['kept_job_present'])
+        self.assertTrue(self.res['kept_upload_present'])
+
+    def test_reusing_the_username_inherits_nothing(self):
+        self.assertEqual(self.res['inherited_job_count'], 0)
+
+
+class TestSessionRevocation(unittest.TestCase):
+    """A signed cookie must not outlive the account it names."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            before = user.get('/api/jobs').status_code
+            admin.delete('/api/users/cook')
+            after = user.get('/api/jobs').status_code
+
+            # Demotion has to bite immediately too, or a demoted admin keeps
+            # reading the API keys until their cookie expires.
+            database.create_local_user('second', hashed(), is_admin=True)
+            other_admin = sign_in('second')
+            admin_before = other_admin.get('/api/config').status_code
+            admin.patch('/api/users/second', json={'is_admin': False})
+            admin_after = other_admin.get('/api/config').status_code
+            me_after = other_admin.get('/api/me').get_json()
+
+            emit(
+                before=before, after=after,
+                admin_before=admin_before, admin_after=admin_after,
+                me_is_admin_after=me_after['is_admin'],
+            )
+        """)
+
+    def test_deleted_account_loses_access_at_once(self):
+        self.assertEqual(self.res['before'], 200)
+        self.assertEqual(self.res['after'], 401)
+
+    def test_demotion_applies_to_a_live_session(self):
+        self.assertEqual(self.res['admin_before'], 200)
+        self.assertEqual(self.res['admin_after'], 403)
+
+    def test_api_me_reports_the_current_rights(self):
+        """The UI keys admin-only sections off this, so it must not go stale."""
+        self.assertFalse(self.res['me_is_admin_after'])
+
+
+class TestChangeOwnPassword(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            wrong = user.post('/api/me/password', json={
+                'current_password': 'not the password',
+                'new_password': OTHER_PASSWORD,
+            })
+            login_throttle.clear_all()
+
+            weak = user.post('/api/me/password', json={
+                'current_password': PASSWORD, 'new_password': 'short',
+            })
+
+            changed = user.post('/api/me/password', json={
+                'current_password': PASSWORD, 'new_password': OTHER_PASSWORD,
+            })
+
+            login_throttle.clear_all()
+            old_login = app.test_client().post('/auth/local/login',
+                json={'username': 'cook', 'password': PASSWORD})
+            login_throttle.clear_all()
+            new_login = app.test_client().post('/auth/local/login',
+                json={'username': 'cook', 'password': OTHER_PASSWORD})
+
+            still_signed_in = user.get('/api/jobs').status_code
+
+            anon = app.test_client().post('/api/me/password', json={
+                'current_password': PASSWORD, 'new_password': OTHER_PASSWORD,
+            })
+
+            emit(
+                wrong_status=wrong.status_code,
+                weak_status=weak.status_code,
+                changed_status=changed.status_code,
+                old_login=old_login.status_code,
+                new_login=new_login.status_code,
+                still_signed_in=still_signed_in,
+                anon_status=anon.status_code,
+            )
+        """)
+
+    def test_the_current_password_is_required(self):
+        """Otherwise a borrowed session could lock the owner out."""
+        self.assertEqual(self.res['wrong_status'], 403)
+
+    def test_the_new_password_must_meet_the_policy(self):
+        self.assertEqual(self.res['weak_status'], 400)
+
+    def test_changing_it_replaces_the_old_one(self):
+        self.assertEqual(self.res['changed_status'], 200)
+        self.assertEqual(self.res['old_login'], 401)
+        self.assertEqual(self.res['new_login'], 200)
+
+    def test_the_session_that_changed_it_stays_signed_in(self):
+        self.assertEqual(self.res['still_signed_in'], 200)
+
+    def test_anonymous_callers_are_refused(self):
+        self.assertEqual(self.res['anon_status'], 401)
+
+
+class TestChangePasswordThrottling(unittest.TestCase):
+    """Guessing the current password is a credential attack like any other."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_local("""
+            admin, user = seed()
+
+            statuses = []
+            for _ in range(5):
+                statuses.append(user.post('/api/me/password', json={
+                    'current_password': 'wrong guess here',
+                    'new_password': OTHER_PASSWORD,
+                }).status_code)
+
+            emit(statuses=statuses)
+        """)
+
+    def test_repeated_wrong_guesses_get_throttled(self):
+        self.assertIn(429, self.res['statuses'])
+
+
+class TestAuthentikModeRefusesUserAdmin(unittest.TestCase):
+    """Under SSO the identity provider owns accounts, so local CRUD is a lie.
+
+    Creating an account here could not sign in (password login is refused), and
+    deleting one would not keep anyone out, since the next OIDC login recreates
+    it. Better to say so than to offer controls that do nothing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _result(_run(textwrap.dedent(f"""
+            import database
+            from app import app
+            app.config['TESTING'] = True
+
+            database.upsert_oidc_user(sub='sub-1', username='boss', is_admin=True)
+            client = app.test_client()
+            with client.session_transaction() as sess:
+                sess['user'] = 'boss'
+                sess['is_admin'] = True
+
+            listed = client.get('/api/users')
+            created = client.post('/api/users', json={{
+                'username': 'nope', 'password': {PASSWORD!r},
+            }})
+            patched = client.patch('/api/users/boss', json={{'is_admin': False}})
+            deleted = client.delete('/api/users/boss')
+            own_password = client.post('/api/me/password', json={{
+                'current_password': 'x', 'new_password': {PASSWORD!r},
+            }})
+
+            emit(
+                listed_status=listed.status_code,
+                created_status=created.status_code,
+                patched_status=patched.status_code,
+                deleted_status=deleted.status_code,
+                own_password_status=own_password.status_code,
+                boss_survives=database.get_user('boss') is not None,
+            )
+        """), AUTH_MODE='authentik',
+            AUTHENTIK_CLIENT_ID='id', AUTHENTIK_CLIENT_SECRET='secret'))
+
+    def test_listing_still_works_for_visibility(self):
+        self.assertEqual(self.res['listed_status'], 200)
+
+    def test_mutations_are_refused(self):
+        self.assertEqual(self.res['created_status'], 400)
+        self.assertEqual(self.res['patched_status'], 400)
+        self.assertEqual(self.res['deleted_status'], 400)
+        self.assertTrue(self.res['boss_survives'])
+
+    def test_own_password_change_is_refused(self):
+        self.assertEqual(self.res['own_password_status'], 400)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ui/README.md
+++ b/ui/README.md
@@ -69,7 +69,9 @@ Sign-in is always required. `AUTH_MODE` picks where accounts come from:
 - `local` (default) — username and password accounts stored by this app, hashed
   with Argon2id. No identity provider needed: with no account yet, every page
   redirects to `/setup`, which closes for good once one exists. Only an admin
-  can add further accounts; there is no self-registration.
+  can add further accounts; there is no self-registration. Admins manage accounts
+  from the settings page: add, promote, demote, set a password, delete. You
+  cannot demote yourself or the last admin.
 - `authentik` — Authentik single sign-on (OIDC). Needs `AUTHENTIK_CLIENT_ID` and
   `AUTHENTIK_CLIENT_SECRET`. Password sign-in is refused in this mode.
 
@@ -147,6 +149,14 @@ The UI uses Socket.IO for real-time progress updates. The stages are:
 ## Security Notes
 
 - Authentication cannot be switched off; Settings holds third-party API keys
+- Reading or writing config, importing/exporting settings and uploading cookies
+  require an admin; a plain account gets a 403
+- In `local` mode the session is resolved against the `users` table on every
+  request, so deleting or demoting an account revokes it immediately instead of
+  when its cookie expires
+- Account lifecycle events (creation, deletion, admin changes, password changes,
+  sign-in successes and failures) are logged; usernames rejected if they contain
+  control characters, which would otherwise let one forge log lines
 - Local passwords are Argon2id hashes with a per-account salt, rehashed on login
   when cost parameters change; failed sign-ins are progressively delayed per
   (IP, username) rather than locking the account

--- a/ui/app.py
+++ b/ui/app.py
@@ -24,11 +24,13 @@ from flask_socketio import SocketIO, emit, join_room, leave_room
 import mobile_auth
 import passwords
 import login_throttle
+from helpers import setup_logger
 from database import (
     init_db, load_config, save_config,
     get_user, upsert_oidc_user,
     local_account_exists, claim_first_local_admin, set_user_password,
     sole_passwordless_username,
+    list_users, count_admins, create_local_user, set_user_admin, delete_user,
     get_history, get_history_entry, get_history_count, delete_history_entry,
     delete_history_entries_bulk, delete_job_entry, delete_jobs_bulk,
     get_combined_history_and_jobs, get_combined_history_and_jobs_count,
@@ -200,6 +202,11 @@ job_manager = init_job_manager(socketio)
 _DEFAULT_LOCAL_USERNAME = 'admin'
 AUTH_MODE = (os.environ.get('AUTH_MODE') or 'local').strip().lower()
 
+# Account lifecycle goes through a logger rather than print(): these are the
+# records you go looking for after something unexpected, and stdout buffering
+# means a print can still be sitting unflushed when the process is killed.
+auth_log = setup_logger('auth')
+
 if AUTH_MODE == 'none':
     # Accepted rather than rejected so existing deployments still boot. They
     # land on first-run setup, which adopts the passwordless account that this
@@ -278,17 +285,69 @@ def _bearer_identity() -> dict | None:
     return identity
 
 
+def _session_account() -> dict | None:
+    """The account the session cookie names, re-read from the database.
+
+    Cached per request. Local mode has to consult the database rather than
+    trusting the cookie: an admin who deletes or demotes someone expects that
+    to take effect now, and a signed cookie would otherwise keep working until
+    it expired. Returns None once the account is gone or has lost its password.
+
+    Authentik mode keeps trusting the cookie. Admin there comes from group
+    membership resolved at sign-in, and the local row is a cache of the last
+    login rather than the authority, so re-reading it would decide access from
+    stale data.
+    """
+    if not LOCAL_AUTH:
+        return None
+    if hasattr(g, '_session_account'):
+        return g._session_account
+
+    username = session.get('user')
+    account = get_user(username) if username else None
+    if account is not None and not account.get('password_hash'):
+        # Left without a password, so nothing can authenticate as it any more.
+        account = None
+    g._session_account = account
+    return account
+
+
+def _session_identity() -> dict | None:
+    """{'username', 'is_admin'} for a cookie session, or None if it is not valid."""
+    if 'user' not in session:
+        return None
+    if not LOCAL_AUTH:
+        return {
+            'username': session['user'],
+            'is_admin': bool(session.get('is_admin')),
+        }
+    account = _session_account()
+    if account is None:
+        return None
+    return {
+        'username': account['username'],
+        'is_admin': bool(account['is_admin']),
+    }
+
+
+def _current_identity() -> dict | None:
+    """Who is making this request: the cookie session, else a Bearer token."""
+    try:
+        identity = _session_identity()
+    except RuntimeError:  # outside a request context
+        identity = None
+    if identity is not None:
+        return identity
+    return _bearer_identity_safe()
+
+
 def _is_logged_in() -> bool:
-    if 'user' in session:
-        return True
-    return _bearer_identity_safe() is not None
+    return _current_identity() is not None
 
 
 def _current_user_is_admin() -> bool:
-    bearer = _bearer_identity_safe()
-    if bearer is not None:
-        return bearer['is_admin']
-    return bool(session.get('is_admin'))
+    identity = _current_identity()
+    return bool(identity and identity['is_admin'])
 
 
 def _bearer_identity_safe() -> dict | None:
@@ -300,10 +359,8 @@ def _bearer_identity_safe() -> dict | None:
 
 def _current_username() -> str | None:
     """Effective owner for the request: the session user, or a Bearer identity."""
-    bearer = _bearer_identity_safe()
-    if bearer is not None:
-        return bearer['username']
-    return session.get('user')
+    identity = _current_identity()
+    return identity['username'] if identity else None
 
 
 def _setup_required() -> bool:
@@ -338,6 +395,23 @@ def api_login_required(f):
     def decorated_function(*args, **kwargs):
         if not _is_logged_in():
             return jsonify({'error': 'Authentication required'}), 401
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+def api_admin_required(f):
+    """Require an admin for API routes.
+
+    401 when nobody is signed in and 403 when someone is but lacks the rights,
+    so a client can tell "log in again" from "you cannot do this".
+    """
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        identity = _current_identity()
+        if identity is None:
+            return jsonify({'error': 'Authentication required'}), 401
+        if not identity['is_admin']:
+            return jsonify({'error': 'Admin access required'}), 403
         return f(*args, **kwargs)
     return decorated_function
 
@@ -582,12 +656,27 @@ def _adoptable_username() -> str | None:
     return sole_passwordless_username()
 
 
-def _validate_new_account(username: str, password: str, confirm: str) -> str | None:
-    """Reason the proposed first account is unacceptable, or None if it is fine."""
+def _validate_username(username: str) -> str | None:
+    """Reason the username is unacceptable, or None if it is fine.
+
+    Control characters are rejected rather than stripped: a name containing a
+    newline could forge entries in the account audit log, and one containing
+    other invisibles would be impossible to type at the sign-in form.
+    """
     if not username:
         return 'Choose a username.'
     if len(username) > 64:
         return 'Username must be at most 64 characters.'
+    if any(ch.isspace() or ord(ch) < 0x20 or ord(ch) == 0x7F for ch in username):
+        return 'Username cannot contain spaces or control characters.'
+    return None
+
+
+def _validate_new_account(username: str, password: str, confirm: str) -> str | None:
+    """Reason the proposed first account is unacceptable, or None if it is fine."""
+    problem = _validate_username(username)
+    if problem:
+        return problem
     if password != confirm:
         return 'The two passwords do not match.'
     try:
@@ -639,7 +728,7 @@ def setup():
         # Another request completed setup between the guard and the write.
         return redirect(url_for('login'))
 
-    print(f"[Auth] first account created: {user['username']}")
+    auth_log.info('first account created: %s', user['username'])
     _establish_session(user['username'], is_admin=True)
     return redirect(url_for('index'))
 
@@ -677,7 +766,7 @@ def api_setup():
     if user is None:
         return jsonify({'error': 'Setup has already been completed.'}), 409
 
-    print(f"[Auth] first account created: {user['username']}")
+    auth_log.info('first account created: %s', user['username'])
     _establish_session(user['username'], is_admin=True)
     return jsonify({'user': user['username'], 'is_admin': True})
 
@@ -701,25 +790,36 @@ def auth_local_login():
     throttle_key = f'{_client_ip()}|{username.lower()}'
     wait = login_throttle.retry_after(throttle_key)
     if wait > 0:
+        auth_log.warning('sign-in throttled for %r from %s',
+                         username, _client_ip())
         return _login_failed(
             f'Too many attempts. Try again in {int(wait) + 1} seconds.',
             429,
             retry_after=int(wait) + 1,
         )
 
+    # Logged as separate reasons on purpose. The response cannot distinguish
+    # them without telling an attacker which usernames exist, but the operator
+    # reading the log needs to: many misses across distinct names is credential
+    # stuffing, while repeated misses on one real name is a targeted guess.
     user = get_user(username) if username else None
     if user is None:
         # Spend comparable time to a real check: otherwise a fast rejection
         # reveals that the username does not exist.
         passwords.dummy_verify()
         login_throttle.record_failure(throttle_key)
+        auth_log.warning('sign-in failed: no such account %r from %s',
+                         username, _client_ip())
         return _login_failed(_INVALID_CREDENTIALS, 401)
 
     if not passwords.verify(user.get('password_hash'), password):
         login_throttle.record_failure(throttle_key)
+        auth_log.warning('sign-in failed: wrong password for %s from %s',
+                         user['username'], _client_ip())
         return _login_failed(_INVALID_CREDENTIALS, 401)
 
     login_throttle.reset(throttle_key)
+    auth_log.info('signed in: %s from %s', user['username'], _client_ip())
 
     # Cost parameters may have risen since this hash was stored; the password is
     # in hand exactly once, so this is the only chance to upgrade it.
@@ -774,7 +874,7 @@ def _resolve_oidc_identity(userinfo: dict) -> tuple[str | None, str | None, bool
     groups = set(userinfo.get('groups') or [])
     is_admin = AUTHENTIK_ADMIN_GROUP in groups
     if not is_admin and AUTHENTIK_USER_GROUP not in groups:
-        print(f"[Auth] denied login for sub={sub}: groups={sorted(groups)}")
+        auth_log.warning('denied login for sub=%s: groups=%s', sub, sorted(groups))
         return sub, None, False
 
     username = (
@@ -1462,10 +1562,15 @@ def reupload_recipe(history_id):
 @app.route('/api/me', methods=['GET'])
 @api_login_required
 def api_me():
+    # From the resolved identity rather than straight out of the cookie, so a
+    # demotion applied while the user was signed in is reflected here — this is
+    # what the UI keys admin-only sections off.
+    identity = _current_identity()
     return jsonify({
-        'user': session['user'],
-        'is_admin': bool(session.get('is_admin', False)),
+        'user': identity['username'],
+        'is_admin': identity['is_admin'],
         'auth_mode': AUTH_MODE,
+        'local_auth_enabled': LOCAL_AUTH,
         # Retained so an older cached frontend bundle keeps working; there is no
         # longer a mode in which authentication is off.
         'auth_disabled': False,
@@ -1553,14 +1658,197 @@ def api_mobile_me():
     return jsonify({'username': identity['username'], 'is_admin': identity['is_admin']})
 
 
-@app.route('/api/config', methods=['GET'])
+# ===== User administration =====
+#
+# Local mode only. Under Authentik the identity provider owns accounts: it
+# decides who exists, group membership decides who administers, and both are
+# reapplied at every sign-in — so creating an account here would be unusable
+# (password sign-in is refused), and deleting one would not keep anyone out.
+
+_LOCAL_ONLY = ('User administration is managed by your identity provider in '
+               'this mode.')
+
+
+def _public_user(user: dict | None) -> dict | None:
+    """An account as the API exposes it: never the password hash."""
+    if user is None:
+        return None
+    return {
+        'username': user['username'],
+        'email': user.get('email'),
+        'name': user.get('name'),
+        'is_admin': bool(user['is_admin']),
+        'is_oidc': user.get('oidc_sub') is not None,
+        'has_password': bool(user.get('password_hash')),
+        'created_at': user.get('created_at'),
+    }
+
+
+def _users_payload():
+    # SQLite hands back 0/1 for the boolean expressions in the query; coerce so
+    # clients get real booleans rather than numbers that are truthy either way.
+    users = [
+        {**row,
+         'is_admin': bool(row['is_admin']),
+         'is_oidc': bool(row['is_oidc']),
+         'has_password': bool(row['has_password'])}
+        for row in list_users()
+    ]
+    return jsonify({'users': users, 'admin_count': count_admins()})
+
+
+@app.route('/api/users', methods=['GET'])
+@api_admin_required
+def api_list_users():
+    return _users_payload()
+
+
+@app.route('/api/users', methods=['POST'])
+@api_admin_required
+def api_create_user():
+    """Add an account. Only an admin can; there is no self-registration."""
+    if not LOCAL_AUTH:
+        return jsonify({'error': _LOCAL_ONLY}), 400
+
+    body = request.get_json(silent=True) or {}
+    username = str(body.get('username') or '').strip()
+    password = str(body.get('password') or '')
+    is_admin = bool(body.get('is_admin'))
+
+    problem = _validate_username(username)
+    if problem:
+        return jsonify({'error': problem}), 400
+    try:
+        passwords.validate(password)
+    except passwords.WeakPassword as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    user = create_local_user(
+        username, passwords.hash_password(password), is_admin=is_admin
+    )
+    if user is None:
+        return jsonify({'error': f'An account named {username} already exists.'}), 409
+
+    auth_log.info('account created: %s (admin=%s) by %s',
+                  username, is_admin, _current_username())
+    return jsonify({'user': _public_user(user)}), 201
+
+
+@app.route('/api/users/<username>', methods=['PATCH'])
+@api_admin_required
+def api_update_user(username: str):
+    """Change another account's admin rights or password."""
+    if not LOCAL_AUTH:
+        return jsonify({'error': _LOCAL_ONLY}), 400
+
+    user = get_user(username)
+    if user is None:
+        return jsonify({'error': 'No such account.'}), 404
+
+    body = request.get_json(silent=True) or {}
+    actor = _current_username()
+
+    if 'is_admin' in body:
+        is_admin = bool(body['is_admin'])
+        # Demoting yourself is how an instance ends up with no admin at all,
+        # and you would lose the rights needed to undo it.
+        if username == actor and not is_admin:
+            return jsonify({'error': 'You cannot remove your own admin rights.'}), 400
+        if not is_admin and bool(user['is_admin']) and count_admins() <= 1:
+            return jsonify({'error': 'The last admin cannot be demoted.'}), 400
+        set_user_admin(username, is_admin)
+
+    if 'password' in body:
+        password = str(body.get('password') or '')
+        try:
+            passwords.validate(password)
+        except passwords.WeakPassword as exc:
+            return jsonify({'error': str(exc)}), 400
+        set_user_password(username, passwords.hash_password(password))
+        # Their sessions keep working: the cookie is checked against the account
+        # existing, not against the password. Signing them out here would be
+        # security theatre if they are the ones who asked for the reset, and a
+        # nuisance if they are not.
+        auth_log.info('password reset for %s by %s', username, actor)
+
+    return jsonify({'user': _public_user(get_user(username))})
+
+
+@app.route('/api/users/<username>', methods=['DELETE'])
+@api_admin_required
+def api_delete_user(username: str):
+    """Remove an account, along with the jobs and uploads it owns."""
+    if not LOCAL_AUTH:
+        return jsonify({'error': _LOCAL_ONLY}), 400
+
+    actor = _current_username()
+    user = get_user(username)
+    if user is None:
+        return jsonify({'error': 'No such account.'}), 404
+    if username == actor:
+        return jsonify({'error': 'You cannot delete your own account.'}), 400
+    if bool(user['is_admin']) and count_admins() <= 1:
+        return jsonify({'error': 'The last admin cannot be deleted.'}), 400
+
+    delete_user(username)
+    auth_log.info('account deleted: %s by %s', username, actor)
+    return jsonify({'status': 'deleted', 'username': username})
+
+
+@app.route('/api/me/password', methods=['POST'])
 @api_login_required
+def api_change_own_password():
+    """Change your own password, proving you know the current one.
+
+    Requiring the current password means a borrowed session or a stolen cookie
+    cannot be used to lock the real owner out of their account.
+    """
+    if not LOCAL_AUTH:
+        return jsonify({'error': 'Passwords are managed by your identity '
+                                 'provider in this mode.'}), 400
+
+    username = _current_username()
+    user = get_user(username) if username else None
+    if user is None:
+        return jsonify({'error': 'Authentication required'}), 401
+
+    body = request.get_json(silent=True) or {}
+    current = str(body.get('current_password') or '')
+    new_password = str(body.get('new_password') or '')
+
+    throttle_key = f'{_client_ip()}|{(username or "").lower()}|change'
+    wait = login_throttle.retry_after(throttle_key)
+    if wait > 0:
+        return jsonify({
+            'error': f'Too many attempts. Try again in {int(wait) + 1} seconds.'
+        }), 429
+
+    if not passwords.verify(user.get('password_hash'), current):
+        login_throttle.record_failure(throttle_key)
+        return jsonify({'error': 'Current password is incorrect.'}), 403
+    login_throttle.reset(throttle_key)
+
+    try:
+        passwords.validate(new_password)
+    except passwords.WeakPassword as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    set_user_password(user['username'], passwords.hash_password(new_password))
+    auth_log.info('password changed by %s', user['username'])
+    return jsonify({'status': 'changed'})
+
+
+# Configuration is instance-wide and holds the LLM, Mealie and Tandoor API keys,
+# so reading it is as sensitive as writing it: a non-admin who could GET this
+# would walk away with the keys. Admin-only in both directions.
+@app.route('/api/config', methods=['GET'])
+@api_admin_required
 def api_get_config():
     return jsonify(load_config())
 
 
 @app.route('/api/config', methods=['POST'])
-@api_login_required
+@api_admin_required
 def api_post_config():
     from config import DEFAULT_CONFIG
     data = request.get_json()
@@ -1579,7 +1867,7 @@ def api_post_config():
 # ===== Settings Export/Import API Endpoints =====
 
 @app.route('/api/settings/export', methods=['GET'])
-@api_login_required
+@api_admin_required
 def export_settings():
     """Export all settings as JSON for backup/transfer."""
     config = load_config()
@@ -1595,7 +1883,7 @@ def export_settings():
 
 
 @app.route('/api/settings/import', methods=['POST'])
-@api_login_required
+@api_admin_required
 def import_settings():
     """Import settings from a JSON backup file."""
     from config import DEFAULT_CONFIG
@@ -1633,8 +1921,10 @@ def import_settings():
     })
 
 
+# Cookies authenticate yt-dlp as whoever exported them, and the path is written
+# into instance-wide config, so this is an admin operation like the rest of it.
 @app.route('/api/cookies/upload', methods=['POST'])
-@api_login_required
+@api_admin_required
 def upload_cookies_file():
     """Upload a cookies.txt file for yt-dlp authentication.
     
@@ -1697,7 +1987,7 @@ def upload_cookies_file():
 
 
 @app.route('/api/cookies/delete', methods=['DELETE'])
-@api_login_required
+@api_admin_required
 def delete_cookies_file():
     """Delete the uploaded cookies file."""
     from config import DATA_DIR

--- a/ui/database.py
+++ b/ui/database.py
@@ -407,6 +407,105 @@ def get_user_by_sub(sub: str) -> Optional[Dict[str, Any]]:
         return dict(row) if row else None
 
 
+# ===== User Administration =====
+
+def list_users() -> List[Dict[str, Any]]:
+    """Every account, oldest first, without the password hashes.
+
+    Deliberately does not select password_hash: nothing outside authentication
+    needs it, and leaving it out means it cannot be leaked by a caller that
+    forgets to strip it.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT username, email, name, avatar_url, is_admin, created_at,
+                   oidc_sub IS NOT NULL AS is_oidc,
+                   (password_hash IS NOT NULL AND password_hash != '') AS has_password
+            FROM users
+            ORDER BY created_at, id
+        ''')
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def count_admins() -> int:
+    """How many accounts can administer the instance."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT COUNT(*) FROM users WHERE is_admin = 1')
+        return cursor.fetchone()[0]
+
+
+def create_local_user(username: str, password_hash: str, *,
+                      is_admin: bool = False) -> Optional[Dict[str, Any]]:
+    """Add a password account. None if the username is already taken.
+
+    Relies on the UNIQUE constraint rather than a check-then-insert, so two
+    concurrent creations cannot both succeed.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                '''INSERT INTO users (username, oidc_sub, email, name, avatar_url,
+                                      is_admin, password_hash)
+                   VALUES (?, NULL, NULL, ?, NULL, ?, ?)''',
+                (username, username, int(is_admin), password_hash),
+            )
+        except sqlite3.IntegrityError:
+            return None
+        conn.commit()
+        return get_user(username)
+
+
+def set_user_admin(username: str, is_admin: bool) -> bool:
+    """Grant or revoke admin rights. False if there is no such account."""
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            'UPDATE users SET is_admin = ? WHERE username = ?',
+            (int(is_admin), username),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def delete_user(username: str) -> bool:
+    """Remove an account and the work it owns. False if there is no such account.
+
+    Ownership is recorded as the username string, not the row id, so leaving the
+    rows behind would hand them to the next account created with the same name.
+    Queued jobs and pending uploads go with the account; entries in
+    recipe_history do not, because that table has no owner column — extracted
+    recipes belong to the instance and outlive whoever queued them.
+
+    One transaction, so a failure part-way cannot leave an account deleted with
+    its jobs still addressable, or vice versa.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute('BEGIN IMMEDIATE')
+        cursor.execute('SELECT 1 FROM users WHERE username = ?', (username,))
+        if cursor.fetchone() is None:
+            conn.rollback()
+            return False
+
+        # Also by job, not just by user_id: an upload created before ownership
+        # was recorded carries a NULL user_id, and leaving it would point at a
+        # job that is about to disappear.
+        cursor.execute(
+            '''DELETE FROM pending_uploads
+               WHERE user_id = ?
+                  OR job_id IN (SELECT id FROM recipe_jobs WHERE user_id = ?)''',
+            (username, username),
+        )
+        cursor.execute('DELETE FROM recipe_jobs WHERE user_id = ?', (username,))
+        cursor.execute('DELETE FROM push_subscriptions WHERE username = ?', (username,))
+        cursor.execute('DELETE FROM users WHERE username = ?', (username,))
+        conn.commit()
+        return True
+
+
 # ===== Config Functions =====
 
 def set_config_value(key: str, value: str) -> bool:

--- a/ui/frontend/src/components/settings/account-card.tsx
+++ b/ui/frontend/src/components/settings/account-card.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { KeyRoundIcon } from 'lucide-react'
+
+import { api } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const MIN_PASSWORD_LENGTH = 10
+
+/** Change your own password. Shown to every user, admin or not. */
+export function AccountCard({ username }: { username: string }) {
+  const [current, setCurrent] = useState('')
+  const [next, setNext] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const mismatch = confirm.length > 0 && next !== confirm
+  const canSubmit =
+    current.length > 0 &&
+    next.length >= MIN_PASSWORD_LENGTH &&
+    next === confirm &&
+    !saving
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setSaving(true)
+    try {
+      await api.changeOwnPassword(current, next)
+      setCurrent('')
+      setNext('')
+      setConfirm('')
+      toast.success('Password changed')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not change password')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <KeyRoundIcon className="size-4" />
+          Your account
+        </CardTitle>
+        <CardDescription>
+          Signed in as <span className="font-medium text-foreground">{username}</span>.
+          Change your password below.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="current-password">Current password</Label>
+            <Input
+              id="current-password"
+              type="password"
+              value={current}
+              onChange={e => setCurrent(e.target.value)}
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-password">New password</Label>
+            <Input
+              id="new-password"
+              type="password"
+              value={next}
+              onChange={e => setNext(e.target.value)}
+              autoComplete="new-password"
+              minLength={MIN_PASSWORD_LENGTH}
+            />
+            <p className="text-xs text-muted-foreground">
+              At least {MIN_PASSWORD_LENGTH} characters.
+            </p>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="confirm-password">Confirm new password</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              value={confirm}
+              onChange={e => setConfirm(e.target.value)}
+              autoComplete="new-password"
+              minLength={MIN_PASSWORD_LENGTH}
+              aria-invalid={mismatch}
+            />
+            {mismatch && (
+              <p className="text-xs text-destructive">
+                The two passwords do not match.
+              </p>
+            )}
+          </div>
+          <Button type="submit" disabled={!canSubmit} className="self-start">
+            {saving ? 'Changing…' : 'Change password'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/frontend/src/components/settings/users-card.tsx
+++ b/ui/frontend/src/components/settings/users-card.tsx
@@ -1,0 +1,413 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { KeyRoundIcon, Trash2Icon, UserPlusIcon, UsersIcon } from 'lucide-react'
+
+import { api } from '@/lib/api'
+import type { ManagedUser } from '@/types'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+
+const MIN_PASSWORD_LENGTH = 10
+
+function AddUserDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const queryClient = useQueryClient()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [isAdmin, setIsAdmin] = useState(false)
+
+  const reset = () => {
+    setUsername('')
+    setPassword('')
+    setIsAdmin(false)
+  }
+
+  const create = useMutation({
+    mutationFn: () => api.createUser(username.trim(), password, isAdmin),
+    onSuccess: async ({ user }) => {
+      await queryClient.invalidateQueries({ queryKey: ['users'] })
+      toast.success(`Created ${user.username}`)
+      reset()
+      onOpenChange(false)
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Could not create the account')
+    },
+  })
+
+  const canSubmit =
+    username.trim().length > 0 &&
+    password.length >= MIN_PASSWORD_LENGTH &&
+    !create.isPending
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) reset()
+        onOpenChange(next)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add an account</DialogTitle>
+          <DialogDescription>
+            You choose the password and pass it on yourself — there is no
+            self-registration and no invitation email.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={e => {
+            e.preventDefault()
+            if (canSubmit) create.mutate()
+          }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-username">Username</Label>
+            <Input
+              id="new-username"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              autoCapitalize="none"
+              spellCheck={false}
+              autoComplete="off"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-user-password">Password</Label>
+            <Input
+              id="new-user-password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              autoComplete="new-password"
+              minLength={MIN_PASSWORD_LENGTH}
+            />
+            <p className="text-xs text-muted-foreground">
+              At least {MIN_PASSWORD_LENGTH} characters. They can change it once
+              signed in.
+            </p>
+          </div>
+          <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
+            <div>
+              <Label htmlFor="new-user-admin">Administrator</Label>
+              <p className="text-xs text-muted-foreground">
+                Can change settings, see everyone's extractions, and manage
+                accounts.
+              </p>
+            </div>
+            <Switch
+              id="new-user-admin"
+              checked={isAdmin}
+              onCheckedChange={setIsAdmin}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {create.isPending ? 'Creating…' : 'Create account'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ResetPasswordDialog({
+  user,
+  onClose,
+}: {
+  user: ManagedUser | null
+  onClose: () => void
+}) {
+  const [password, setPassword] = useState('')
+
+  const reset = useMutation({
+    mutationFn: () => api.resetUserPassword(user!.username, password),
+    onSuccess: () => {
+      toast.success(`Password set for ${user!.username}`)
+      setPassword('')
+      onClose()
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Could not set the password')
+    },
+  })
+
+  return (
+    <Dialog
+      open={user !== null}
+      onOpenChange={next => {
+        if (!next) {
+          setPassword('')
+          onClose()
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Set a new password</DialogTitle>
+          <DialogDescription>
+            For {user?.username}. Their existing sessions stay signed in; the new
+            password applies the next time they sign in.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={e => {
+            e.preventDefault()
+            if (password.length >= MIN_PASSWORD_LENGTH) reset.mutate()
+          }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="reset-password">New password</Label>
+            <Input
+              id="reset-password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              autoComplete="new-password"
+              minLength={MIN_PASSWORD_LENGTH}
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={password.length < MIN_PASSWORD_LENGTH || reset.isPending}
+            >
+              {reset.isPending ? 'Setting…' : 'Set password'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function UserRow({
+  user,
+  isSelf,
+  lastAdmin,
+  onResetPassword,
+  onDelete,
+}: {
+  user: ManagedUser
+  isSelf: boolean
+  lastAdmin: boolean
+  onResetPassword: () => void
+  onDelete: () => void
+}) {
+  const queryClient = useQueryClient()
+
+  const toggleAdmin = useMutation({
+    mutationFn: (next: boolean) => api.setUserAdmin(user.username, next),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['users'] })
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Could not change rights')
+    },
+  })
+
+  // Guarded here as well as on the server, so the control explains itself
+  // instead of only failing when pressed.
+  const adminLocked = isSelf || (user.is_admin && lastAdmin)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-b border-border py-3 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-medium">{user.username}</span>
+          {isSelf && <Badge variant="secondary">you</Badge>}
+          {user.is_oidc && <Badge variant="outline">SSO</Badge>}
+          {!user.has_password && !user.is_oidc && (
+            <Badge variant="outline">no password</Badge>
+          )}
+        </div>
+        {user.email && (
+          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Label
+          htmlFor={`admin-${user.username}`}
+          className="text-xs text-muted-foreground"
+        >
+          Admin
+        </Label>
+        <Switch
+          id={`admin-${user.username}`}
+          checked={user.is_admin}
+          disabled={adminLocked || toggleAdmin.isPending}
+          onCheckedChange={next => toggleAdmin.mutate(next)}
+        />
+      </div>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onResetPassword}
+        title="Set a new password"
+      >
+        <KeyRoundIcon />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onDelete}
+        disabled={isSelf || (user.is_admin && lastAdmin)}
+        title={isSelf ? 'You cannot delete your own account' : 'Delete account'}
+      >
+        <Trash2Icon />
+      </Button>
+    </div>
+  )
+}
+
+/**
+ * Account management. Admin-only, and local-mode only: under Authentik the
+ * identity provider owns accounts and group membership owns admin rights.
+ */
+export function UsersCard({ currentUsername }: { currentUsername: string }) {
+  const queryClient = useQueryClient()
+  const [adding, setAdding] = useState(false)
+  const [resetting, setResetting] = useState<ManagedUser | null>(null)
+  const [deleting, setDeleting] = useState<ManagedUser | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['users'],
+    queryFn: api.listUsers,
+  })
+
+  const remove = useMutation({
+    mutationFn: (username: string) => api.deleteUser(username),
+    onSuccess: async ({ username }) => {
+      await queryClient.invalidateQueries({ queryKey: ['users'] })
+      await queryClient.invalidateQueries({ queryKey: ['tasks'] })
+      toast.success(`Deleted ${username}`)
+      setDeleting(null)
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Could not delete the account')
+    },
+  })
+
+  const lastAdmin = (data?.admin_count ?? 0) <= 1
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <UsersIcon className="size-4" />
+          Accounts
+        </CardTitle>
+        <CardDescription>
+          Everyone who can sign in to this instance. Only administrators can add
+          or remove accounts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {isLoading ? (
+          <div className="h-9 w-full animate-pulse rounded-lg bg-muted" />
+        ) : (
+          <div className="flex flex-col">
+            {data?.users.map(user => (
+              <UserRow
+                key={user.username}
+                user={user}
+                isSelf={user.username === currentUsername}
+                lastAdmin={lastAdmin}
+                onResetPassword={() => setResetting(user)}
+                onDelete={() => setDeleting(user)}
+              />
+            ))}
+          </div>
+        )}
+
+        <Button
+          variant="outline"
+          className="self-start"
+          onClick={() => setAdding(true)}
+        >
+          <UserPlusIcon />
+          Add account
+        </Button>
+      </CardContent>
+
+      <AddUserDialog open={adding} onOpenChange={setAdding} />
+      <ResetPasswordDialog user={resetting} onClose={() => setResetting(null)} />
+
+      <AlertDialog
+        open={deleting !== null}
+        onOpenChange={next => {
+          if (!next) setDeleting(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {deleting?.username}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Their queued extractions and pending uploads are deleted with the
+              account. Recipes already saved to your history belong to the
+              instance and are kept.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleting && remove.mutate(deleting.username)}
+            >
+              Delete account
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  )
+}

--- a/ui/frontend/src/lib/api.ts
+++ b/ui/frontend/src/lib/api.ts
@@ -275,6 +275,45 @@ export const api = {
       handle401: true,
     }),
 
+  // ===== User administration (admin only, local mode only) =====
+  listUsers: () =>
+    request<{ users: import('@/types').ManagedUser[]; admin_count: number }>(
+      '/api/users',
+    ),
+
+  createUser: (username: string, password: string, isAdmin: boolean) =>
+    request<{ user: import('@/types').ManagedUser }>('/api/users', {
+      method: 'POST',
+      json: { username, password, is_admin: isAdmin },
+    }),
+
+  setUserAdmin: (username: string, isAdmin: boolean) =>
+    request<{ user: import('@/types').ManagedUser }>(
+      `/api/users/${encodeURIComponent(username)}`,
+      { method: 'PATCH', json: { is_admin: isAdmin } },
+    ),
+
+  resetUserPassword: (username: string, password: string) =>
+    request<{ user: import('@/types').ManagedUser }>(
+      `/api/users/${encodeURIComponent(username)}`,
+      { method: 'PATCH', json: { password } },
+    ),
+
+  deleteUser: (username: string) =>
+    request<{ status: string; username: string }>(
+      `/api/users/${encodeURIComponent(username)}`,
+      { method: 'DELETE' },
+    ),
+
+  // ===== Own account =====
+  // handle401 is off: a 401 here means the session really is gone, and the
+  // redirect to /login is the right answer. A wrong current password is a 403.
+  changeOwnPassword: (currentPassword: string, newPassword: string) =>
+    request<{ status: string }>('/api/me/password', {
+      method: 'POST',
+      json: { current_password: currentPassword, new_password: newPassword },
+    }),
+
   // ===== First-run setup =====
   // Only answers while the instance has no account; 409 once one exists.
   setupInfo: () =>

--- a/ui/frontend/src/pages/settings-page.tsx
+++ b/ui/frontend/src/pages/settings-page.tsx
@@ -13,10 +13,14 @@ import {
   UploadIcon,
   Trash2Icon,
   DownloadIcon,
+  UsersIcon,
 } from 'lucide-react'
 
 import { api } from '@/lib/api'
 import type { AppConfig } from '@/types'
+import { useSession } from '@/hooks/use-session'
+import { AccountCard } from '@/components/settings/account-card'
+import { UsersCard } from '@/components/settings/users-card'
 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
@@ -81,9 +85,16 @@ function Field({ label, hint, children }: { label: string; hint?: React.ReactNod
 
 export function SettingsPage() {
   const queryClient = useQueryClient()
-  const { data: loaded, isLoading } = useQuery({
+  const { data: session, isLoading: sessionLoading } = useSession()
+  const isAdmin = session?.is_admin ?? false
+  const localAuth = session?.local_auth_enabled ?? false
+
+  const { data: loaded, isLoading: configLoading } = useQuery({
     queryKey: ['config'],
     queryFn: () => api.getConfig(),
+    // Instance configuration holds the API keys, so the server refuses it to
+    // non-admins. Not asking avoids a pointless 403 on every visit.
+    enabled: isAdmin,
   })
 
   const { get, set, reset, draft, dirty } = useDraft(loaded)
@@ -174,9 +185,25 @@ export function SettingsPage() {
   const confirmBeforeUpload = get('confirm_before_upload') === 'true'
   const hasCookiesFile = Boolean(loaded?.yt_dlp_cookies_file)
 
-  if (isLoading) {
+  if (sessionLoading || (isAdmin && configLoading)) {
     return (
       <div className="p-6 text-muted-foreground text-sm">Loading settings…</div>
+    )
+  }
+
+  // Non-admins get their own account and nothing else: everything below is
+  // instance-wide, and the server refuses it to them anyway.
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-6 flex flex-col gap-6">
+        <div>
+          <h1 className="text-xl font-semibold">Settings</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Extraction settings are managed by an administrator.
+          </p>
+        </div>
+        {localAuth && session && <AccountCard username={session.user} />}
+      </div>
     )
   }
 
@@ -604,11 +631,31 @@ export function SettingsPage() {
               className="w-28"
             />
           </Field>
-          <p className="text-xs text-muted-foreground">
-            Sign-in and user access are managed via Authentik single sign-on.
-          </p>
         </CardContent>
       </Card>
+
+      {localAuth && session && (
+        <>
+          <AccountCard username={session.user} />
+          <UsersCard currentUsername={session.user} />
+        </>
+      )}
+
+      {!localAuth && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <UsersIcon className="size-4" />
+              Accounts
+            </CardTitle>
+            <CardDescription>
+              Sign-in, accounts and admin rights come from Authentik. Add or
+              remove people there, and use its groups to decide who administers
+              this instance.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
 
       {/* Backup */}
       <Card>

--- a/ui/frontend/src/types.ts
+++ b/ui/frontend/src/types.ts
@@ -293,11 +293,25 @@ export interface SessionUser {
   user: string
   is_admin: boolean
   auth_mode?: 'local' | 'authentik'
+  /** False under Authentik, where the IdP owns accounts and passwords. */
+  local_auth_enabled?: boolean
   /** Always false now; kept so an older cached bundle still parses a response. */
   auth_disabled?: boolean
   /** Popped server-side from the /share flow; consumed once by Home */
   shared_url?: string | null
   auto_start?: boolean
+}
+
+/** An account as /api/users exposes it. Never carries the password hash. */
+export interface ManagedUser {
+  username: string
+  email?: string | null
+  name?: string | null
+  is_admin: boolean
+  /** Came from the identity provider rather than being created here. */
+  is_oidc: boolean
+  has_password: boolean
+  created_at?: string | null
 }
 
 // ===== Socket.IO events =====


### PR DESCRIPTION
## Why

Two problems, both reachable by any signed-in account:

- **Settings was not admin-gated.** `/api/config` returns the LLM, Mealie and Tandoor API keys, and the POST rewrites them. Every signed-in account could read and change them.
- **Revoking access did nothing until the cookie expired.** Identity and admin status were read from the session, so deleting or demoting someone left them working normally until they signed out.

And with local accounts now the default, there was no way to create an account for anyone else — the setup page closes after the first one.

## What changed

**Admin-only settings.** Config read/write, settings import/export and cookie upload/delete require an admin. A plain account opening Settings gets its own password form and nothing else, rather than a page full of 403s.

**Account management** (`/api/users`), local mode only: list, create, promote/demote, set a password for someone who forgot theirs, delete. Two refusals that cannot be worked around, because either would leave the instance locked out: demoting yourself, and demoting the last admin. Self-deletion is refused for the same reason. No self-registration — on a self-hosted instance an open sign-up form is a way in for anyone who finds the URL.

**Deleting an account** removes its queued/in-progress jobs, pending uploads and push subscriptions. Finished recipes stay: they belong to the instance, and the person leaving is usually not the only one who cares about them. This also closes a username-reuse hole — ownership is by username, so without the cleanup a recreated `alice` inherited the old `alice`'s pending work.

**Immediate revocation.** In local mode the session resolves against the `users` table on each request, so a deleted or demoted account loses access on its next request. Mobile token refresh re-reads the account too, so a demoted user cannot mint a fresh admin token.

**Change your own password** (`/api/me/password`) requires the current one, so a borrowed session cannot lock you out of your own account. Throttled on the same ladder as sign-in.

**Audit logging.** Account lifecycle and sign-in events went to `print()`, which buffered and was lost when the process was killed. They now go through the project logger. Usernames containing control characters are refused — a newline in a username would let a created account forge audit lines.

## Tests

`tests/test_user_admin.py`, 34 cases: admin gating, listing/creation and its refusals, admin-rights guards, deletion and cascade, live session revocation on delete and demote, own-password change and its throttling, and that all of it is refused in `authentik` mode where the IdP owns accounts.

168 server tests pass; frontend lints and builds.

## Test plan

- [ ] Fresh instance: create the admin on `/setup`, then add a second account from Settings → Users
- [ ] Sign in as the second account: Settings shows only the password form; `/api/config` returns 403
- [ ] Promote it, reload as that user, confirm the full settings page appears
- [ ] Demote it from the admin's session while it is signed in; its next request loses admin
- [ ] Delete it while signed in; its next request lands back on the login page
- [ ] Confirm you cannot demote or delete yourself, and cannot demote the last admin

Made with [Cursor](https://cursor.com)