### PR TITLE
feat(mobile): choose the server and the sign-in method in the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,18 +245,27 @@ JWT_SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
 ```
 
 With `JWT_SECRET_KEY` unset the whole mobile surface stays disabled and those
-endpoints return 503. The app cannot hold the OIDC client secret, so it opens the
-system browser against Authentik, the server completes the code exchange, and the
-resulting token pair is handed back over a custom-scheme deep link
-(`par://auth/callback` by default, configurable with
-`MOBILE_DEEP_LINK_SCHEMES`). Tokens travel in the URL fragment, which browsers do
-not send to servers or leak via `Referer`.
+endpoints return 503.
+
+The app asks for your server's address on first launch — nothing is compiled in,
+since everyone runs their own instance — then reads `/api/auth/status` and offers
+whichever sign-in that instance has. Under `local` it posts the username and
+password to `/api/mobile/auth/login`, which applies the same throttle ladder as
+the web form, so neither is a way around the other. Under `authentik` a password
+is refused there: group membership governs access, not any password an account
+happens to carry.
+
+For Authentik the app cannot hold the OIDC client secret, so it opens the system
+browser, the server completes the code exchange, and the resulting token pair is
+handed back over a custom-scheme deep link (`par://auth/callback` by default,
+configurable with `MOBILE_DEEP_LINK_SCHEMES`). Tokens travel in the URL fragment,
+which browsers do not send to servers or leak via `Referer`.
 
 Access tokens last 15 minutes and refresh tokens 30 days; `POST
 /api/mobile/auth/refresh` re-reads the account on every refresh, so removing
-someone from the Authentik group takes effect within the access-token lifetime
-rather than lasting for the life of the refresh token. Group membership is
-enforced by the same check as the web flow.
+someone from the Authentik group — or deleting or demoting a local account —
+takes effect within the access-token lifetime rather than lasting for the life of
+the refresh token.
 
 Bearer tokens are accepted on the existing API endpoints alongside cookie
 sessions; cookies take precedence when both are present.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,8 +1,8 @@
 # Pick-a-Recipe — Android app
 
-Flutter client for the Pick-a-Recipe server. Signs in against the same
-Authentik tenant as the web UI and talks to the `/api/mobile/*` endpoints with
-JWT bearer tokens.
+Flutter client for the Pick-a-Recipe server. Asks which instance to talk to,
+then signs in whichever way that instance supports, and talks to the
+`/api/mobile/*` endpoints with JWT bearer tokens.
 
 ## Requirements
 
@@ -10,20 +10,43 @@ JWT bearer tokens.
 - A running Pick-a-Recipe server with `JWT_SECRET_KEY` set — without it the
   mobile endpoints return 503 and sign-in cannot complete
 
+## Which server, and which sign-in
+
+Neither is compiled in. Everyone running Pick-a-Recipe runs their own server
+with their own authentication, so a published APK cannot know either.
+
+On first launch the app asks for a server address. It types short — `https://`
+is assumed, a trailing slash is dropped, a port or subpath is kept — and nothing
+is saved until the address answers, so a typo leaves the form on screen instead
+of stranding the app somewhere unreachable. **Change** on the sign-in screen
+returns to it, clearing the stored tokens along with the address, since tokens
+mean nothing to a different instance.
+
+The app then reads `GET /api/auth/status` and offers only what that server has:
+
+| Server state | What the app shows |
+|--------------|--------------------|
+| `AUTH_MODE=local` | Username and password, posted to `/api/mobile/auth/login` |
+| `AUTH_MODE=authentik` | A button that opens Authentik in the system browser |
+| No account yet | A prompt to finish setup in a browser, and a re-check button |
+| `JWT_SECRET_KEY` unset | An explanation that app sign-in is switched off |
+
+A plain-`http://` address is allowed — plenty of self-hosted instances are HTTP
+on a home network, and refusing would leave those users with no app — but the
+password form says plainly that the password will travel unencrypted.
+
 ## Running
 
-The API host comes from the build flavor, so there is nothing to edit in the
-source:
-
 ```bash
-flutter run                                        # dev: http://10.0.2.2:5006
-flutter run --dart-define=FLAVOR=prod              # https://recipes.pickel.me
-flutter run --dart-define=API_BASE_URL=http://192.168.1.10:5006   # explicit host
+flutter run                                        # prefills http://10.0.2.2:5006
+flutter run --dart-define=FLAVOR=prod              # no prefill, as a release build
+flutter run --dart-define=API_BASE_URL=http://192.168.1.10:5006   # prefill a host
 ```
 
-`10.0.2.2` is the Android emulator's alias for the host machine. On a physical
-device, pass `API_BASE_URL` with your machine's LAN address. Cleartext HTTP is
-permitted only for those loopback/dev hosts; see
+`10.0.2.2` is the Android emulator's alias for the host machine; on a physical
+device use your machine's LAN address. Both only *prefill* the address field —
+the value the app uses is the one entered and stored on the device. Cleartext
+HTTP is permitted only for loopback/dev hosts; see
 `android/app/src/main/res/xml/network_security_config.xml`.
 
 ```bash
@@ -31,7 +54,22 @@ flutter test
 flutter analyze
 ```
 
-## How sign-in works
+## How password sign-in works
+
+Under `AUTH_MODE=local` there is no identity provider to visit, so the app posts
+the credentials itself:
+
+`POST /api/mobile/auth/login` with `{username, password}` returns the same token
+pair the browser flow ends with. The server verifies the Argon2id hash and
+applies the *same* throttle ladder as the web form, keyed on (IP, username) — so
+the app endpoint is not a way around the form's rate limit, or the reverse.
+Wrong password and unknown account are indistinguishable in the response.
+
+The endpoint is refused under `AUTH_MODE=authentik`: there, group membership
+governs access rather than any password an account happens to carry, so
+honouring one would be a way around single sign-on.
+
+## How Authentik sign-in works
 
 The app never handles the OIDC client secret, and no credentials are entered
 inside the app.
@@ -85,10 +123,15 @@ changing both.
 
 ```
 lib/src/
-  config/      build-flavor and API host resolution
-  core/        secure token storage, Dio client + auth interceptor, deep links
+  config/      build flavor and the address prefill
+  core/        secure token + server-address storage, Dio client + auth
+               interceptor, deep links
   features/
-    auth/      sign-in controller, callback parsing, login screen
+    auth/      server address and sign-in controllers, callback parsing,
+               login screen
     home/      signed-in landing screen
   router.dart  go_router with auth-driven redirects
 ```
+
+`Dio`'s base URL is derived from the stored address, so it is rebuilt when the
+server changes and no client is left pointing at the old one.

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'core/deep_links.dart';
 import 'core/providers.dart';
 import 'features/auth/auth_controller.dart';
+import 'features/auth/server_controller.dart';
 import 'router.dart';
 import 'theme/app_theme.dart';
 
@@ -22,10 +23,13 @@ class _PickARecipeAppState extends ConsumerState<PickARecipeApp> {
     super.initState();
     // Deferred so the first frame is not blocked on storage and network, and
     // so reading providers happens outside of initState's build phase.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       final AuthController auth = ref.read(authControllerProvider.notifier);
       _deepLinks.start(auth.completeSignIn);
-      auth.restore();
+      // Server first: a stored session cannot be checked before the app knows
+      // which instance to check it against.
+      await ref.read(serverControllerProvider.notifier).restore();
+      await auth.restore();
     });
   }
 

--- a/mobile/lib/src/config/app_config.dart
+++ b/mobile/lib/src/config/app_config.dart
@@ -5,12 +5,13 @@
 ///   flutter run  --dart-define=FLAVOR=dev
 ///   flutter build apk --release --dart-define=FLAVOR=prod
 ///
-/// API_BASE_URL optionally overrides the host for either flavor without a
-/// code change (useful for pointing a dev build at staging).
+/// The server address is *not* compiled in. Every user runs their own instance,
+/// so a published build cannot know where to point; it is entered in the app and
+/// kept by ServerStore. API_BASE_URL only prefills that field, to save typing
+/// during development.
 class AppConfig {
   const AppConfig({required this.flavor, this.apiBaseUrlOverride});
 
-  static const String _prodHost = 'https://recipes.pickel.me';
   // Android emulator alias for the host machine's loopback interface; the
   // Flask backend listens on port 5006 in local development.
   static const String _devHost = 'http://10.0.2.2:5006';
@@ -18,14 +19,16 @@ class AppConfig {
   /// Either 'dev' or 'prod'.
   final String flavor;
 
-  /// Optional compile-time override of the API base URL.
+  /// Optional compile-time prefill of the server address.
   final String? apiBaseUrlOverride;
 
   bool get isProd => flavor == 'prod';
 
-  /// Base URL of the pick-a-recipe backend, no trailing slash.
-  String get baseUrl =>
-      apiBaseUrlOverride ?? (isProd ? _prodHost : _devHost);
+  /// Prefills the server address field on first launch. Null for release
+  /// builds: guessing there would point somebody else's install at whichever
+  /// instance happened to be convenient when the APK was cut.
+  String? get suggestedServerUrl =>
+      apiBaseUrlOverride ?? (isProd ? null : _devHost);
 
   factory AppConfig.fromDefines() {
     const flavor = String.fromEnvironment('FLAVOR', defaultValue: 'dev');

--- a/mobile/lib/src/core/api_client.dart
+++ b/mobile/lib/src/core/api_client.dart
@@ -7,7 +7,12 @@ import 'token_store.dart';
 /// Backend paths for the mobile auth handshake.
 const String kRefreshPath = '/api/mobile/auth/refresh';
 const String kLoginUrlPath = '/api/mobile/auth/login-url';
+const String kPasswordLoginPath = '/api/mobile/auth/login';
 const String kMobileMePath = '/api/mobile/me';
+
+/// Unauthenticated: how a server describes the way in, before there is any
+/// session to describe it with.
+const String kAuthStatusPath = '/api/auth/status';
 
 /// Attaches the bearer token to outgoing requests and renews it once when the
 /// backend rejects it, so a 15-minute access token expiring mid-session is

--- a/mobile/lib/src/core/providers.dart
+++ b/mobile/lib/src/core/providers.dart
@@ -5,7 +5,10 @@ import 'package:url_launcher/url_launcher.dart';
 import '../config/app_config.dart';
 import '../features/auth/auth_controller.dart';
 import '../features/auth/auth_repository.dart';
+import '../features/auth/server_controller.dart';
+import '../features/auth/server_repository.dart';
 import 'api_client.dart';
+import 'server_store.dart';
 import 'token_store.dart';
 
 /// Overridden with the real [AppConfig] in main() before runApp.
@@ -24,6 +27,19 @@ final tokenStoreProvider = Provider<TokenStore>(
   (ref) => TokenStore(ref.watch(secureStoreProvider)),
 );
 
+final serverStoreProvider = Provider<ServerStore>(
+  (ref) => ServerStore(ref.watch(secureStoreProvider)),
+);
+
+/// Overridden in tests to answer without a network.
+final probeClientFactoryProvider = Provider<ProbeClientFactory>(
+  (ref) => createProbeClient,
+);
+
+final serverRepositoryProvider = Provider<ServerRepository>(
+  (ref) => ServerRepository(ref.watch(probeClientFactoryProvider)),
+);
+
 /// Indirection so tests can assert which URL would have been opened without
 /// launching a real browser.
 typedef UrlLauncher = Future<bool> Function(Uri url);
@@ -33,14 +49,22 @@ final urlLauncherProvider = Provider<UrlLauncher>(
 );
 
 final dioProvider = Provider<Dio>((ref) {
-  return createApiClient(
-    baseUrl: ref.watch(configProvider).baseUrl,
+  // Rebuilt when the server changes, so switching instances cannot leave a
+  // client pointing at the old one. Empty until an address is chosen; the login
+  // screen shows the address form in that state and issues no requests.
+  final String baseUrl = ref.watch(
+    serverControllerProvider.select((state) => state.baseUrl ?? ''),
+  );
+  final Dio dio = createApiClient(
+    baseUrl: baseUrl,
     tokenStore: ref.watch(tokenStoreProvider),
     // A refresh token the server no longer honours ends the session; the
     // router reacts to the state change and shows the login screen.
     onSignedOut: () async =>
         ref.read(authControllerProvider.notifier).signOut(),
   );
+  ref.onDispose(dio.close);
+  return dio;
 });
 
 final authRepositoryProvider = Provider<AuthRepository>(

--- a/mobile/lib/src/core/server_store.dart
+++ b/mobile/lib/src/core/server_store.dart
@@ -1,0 +1,84 @@
+import 'token_store.dart';
+
+/// Which instance this install talks to.
+///
+/// Held per install rather than compiled in: everyone running Pick-a-Recipe
+/// runs their own server, so a published APK cannot know the address. The
+/// compile-time value in [AppConfig] only prefills the field for dev builds.
+///
+/// Stored through [SecureKeyValueStore] for the same reason the tokens are: not
+/// because an address is a secret, but because the tokens beside it are, and one
+/// storage backend is one thing to get right.
+class ServerStore {
+  const ServerStore(this._store);
+
+  static const String _key = 'server.base_url';
+
+  final SecureKeyValueStore _store;
+
+  Future<String?> read() async {
+    final String? saved = await _store.read(_key);
+    if (saved == null || saved.isEmpty) return null;
+    return saved;
+  }
+
+  Future<void> save(String baseUrl) => _store.write(_key, baseUrl);
+
+  Future<void> clear() => _store.delete(_key);
+}
+
+/// Turns what somebody types into a base URL, or returns null if it cannot be
+/// one.
+///
+/// Deliberately forgiving about the parts people leave out — a bare
+/// `recipes.example.com` is what most will type — and strict about the parts
+/// that would silently break every later request, like a trailing slash that
+/// turns into a double slash once a path is appended.
+String? normaliseServerUrl(String input) {
+  String text = input.trim();
+  if (text.isEmpty) return null;
+
+  // Whitespace inside means this is a sentence, not an address. Uri would
+  // otherwise percent-encode it into a plausible-looking host that can never
+  // resolve, and the failure would be blamed on the network.
+  if (RegExp(r'\s').hasMatch(text)) return null;
+
+  // No scheme means https, not "no scheme": defaulting to http would quietly
+  // put a password on the wire in clear.
+  if (!text.contains('://')) {
+    text = 'https://$text';
+  }
+
+  final Uri? url = Uri.tryParse(text);
+  if (url == null) return null;
+  if (url.scheme != 'http' && url.scheme != 'https') return null;
+  if (!_isPlausibleHost(url.host)) return null;
+
+  // Rebuilt part by part rather than with replace(), which keeps a query and
+  // fragment that would end up glued in front of every request path. Any
+  // userinfo is dropped with them: credentials belong in the sign-in form.
+  final String path = url.path.replaceAll(RegExp(r'/+$'), '');
+  return Uri(
+    scheme: url.scheme,
+    host: url.host,
+    port: url.hasPort ? url.port : null,
+    path: path,
+  ).toString();
+}
+
+final RegExp _hostname = RegExp(r'^[A-Za-z0-9]([A-Za-z0-9.\-]*[A-Za-z0-9])?$');
+final RegExp _ipv6 = RegExp(r'^[0-9A-Fa-f:.]+$');
+
+bool _isPlausibleHost(String host) {
+  if (host.isEmpty) return false;
+  // Uri strips the brackets from an IPv6 literal, so it fails the hostname
+  // pattern on its colons alone.
+  return host.contains(':') ? _ipv6.hasMatch(host) : _hostname.hasMatch(host);
+}
+
+/// True for an address whose traffic is readable in transit.
+///
+/// Not blocked: plenty of self-hosted instances are plain HTTP on a home
+/// network, and refusing would leave those users with no app at all. Surfaced
+/// in the UI instead, so the choice is at least an informed one.
+bool isInsecureServerUrl(String baseUrl) => baseUrl.startsWith('http://');

--- a/mobile/lib/src/features/auth/auth_controller.dart
+++ b/mobile/lib/src/features/auth/auth_controller.dart
@@ -34,6 +34,42 @@ class AuthController extends Notifier<AuthState> {
     );
   }
 
+  /// Signs in with an account held by the instance itself.
+  ///
+  /// Unlike the Authentik path this completes in one call, with no browser and
+  /// no deep link: the server hands back the token pair directly.
+  Future<void> signInWithPassword({
+    required String username,
+    required String password,
+  }) async {
+    if (state.isBusy) return;
+    state = state.copyWith(isBusy: true);
+
+    try {
+      final AuthTokens tokens = await _repository.signInWithPassword(
+        username: username,
+        password: password,
+      );
+      await _tokens.save(tokens);
+      final MobileIdentity? identity = await _repository.me();
+      if (identity == null) {
+        await _tokens.clear();
+        state = const AuthState.signedOut(
+          errorMessage: 'Signed in, but the server rejected the session. '
+              'Please try again.',
+        );
+        return;
+      }
+      state = AuthState(
+        status: AuthStatus.signedIn,
+        username: identity.username,
+        isAdmin: identity.isAdmin,
+      );
+    } on AuthApiException catch (error) {
+      state = state.copyWith(isBusy: false, errorMessage: error.message);
+    }
+  }
+
   /// Opens the system browser at Authentik. Control returns to the app through
   /// the deep link handled by [completeSignIn].
   Future<void> signIn() async {

--- a/mobile/lib/src/features/auth/auth_repository.dart
+++ b/mobile/lib/src/features/auth/auth_repository.dart
@@ -1,12 +1,47 @@
 import 'package:dio/dio.dart';
 
 import '../../core/api_client.dart';
+import '../../core/token_store.dart';
 
 class MobileIdentity {
   const MobileIdentity({required this.username, required this.isAdmin});
 
   final String username;
   final bool isAdmin;
+}
+
+/// How a given server expects to be signed into, from `/api/auth/status`.
+///
+/// Read before any credential is asked for, so the app offers the one way in
+/// that instance actually has instead of a guess the server will refuse.
+class ServerAuthStatus {
+  const ServerAuthStatus({
+    required this.localAuthEnabled,
+    required this.ssoEnabled,
+    required this.setupRequired,
+    required this.mobileAuthEnabled,
+  });
+
+  factory ServerAuthStatus.fromJson(Map<String, dynamic> json) {
+    return ServerAuthStatus(
+      localAuthEnabled: json['local_auth_enabled'] as bool? ?? false,
+      ssoEnabled: json['sso_enabled'] as bool? ?? false,
+      setupRequired: json['setup_required'] as bool? ?? false,
+      mobileAuthEnabled: json['mobile_auth_enabled'] as bool? ?? false,
+    );
+  }
+
+  /// Username and password accounts held by the instance itself.
+  final bool localAuthEnabled;
+
+  /// Authentik, reached through the system browser.
+  final bool ssoEnabled;
+
+  /// No account exists yet; nobody can sign in until one is made in a browser.
+  final bool setupRequired;
+
+  /// JWT_SECRET_KEY is set, without which no app sign-in works at all.
+  final bool mobileAuthEnabled;
 }
 
 /// Thrown when the backend refuses a request for a reason worth showing.
@@ -42,6 +77,33 @@ class AuthRepository {
         );
       }
       return Uri.parse(url);
+    } on DioException catch (error) {
+      throw AuthApiException(_describe(error));
+    }
+  }
+
+  /// Exchanges a local username and password for a token pair.
+  ///
+  /// Only servers running `AUTH_MODE=local` accept this; the caller decides
+  /// whether to offer it by reading [ServerAuthStatus] first.
+  Future<AuthTokens> signInWithPassword({
+    required String username,
+    required String password,
+  }) async {
+    try {
+      final Response<Map<String, dynamic>> response =
+          await _dio.post<Map<String, dynamic>>(
+        kPasswordLoginPath,
+        data: <String, String>{'username': username, 'password': password},
+      );
+      final String? access = response.data?['access_token'] as String?;
+      final String? refresh = response.data?['refresh_token'] as String?;
+      if (access == null || refresh == null) {
+        throw const AuthApiException(
+          'The server did not return a session. Please try again.',
+        );
+      }
+      return AuthTokens(accessToken: access, refreshToken: refresh);
     } on DioException catch (error) {
       throw AuthApiException(_describe(error));
     }

--- a/mobile/lib/src/features/auth/login_screen.dart
+++ b/mobile/lib/src/features/auth/login_screen.dart
@@ -1,90 +1,503 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/providers.dart';
+import '../../core/server_store.dart';
 import 'auth_controller.dart';
+import 'auth_repository.dart';
 import 'auth_state.dart';
+import 'server_controller.dart';
+import 'server_state.dart';
 
+/// Sign-in, in two steps: which instance, then how.
+///
+/// The second step is decided by the server rather than the build, because a
+/// published APK is installed by people running their own instances with
+/// different authentication set up.
 class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AuthState auth = ref.watch(authControllerProvider);
+    final ServerState server = ref.watch(serverControllerProvider);
     final ThemeData theme = Theme.of(context);
 
     return Scaffold(
       body: SafeArea(
         child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 420),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  Icon(
-                    Icons.restaurant_menu,
-                    size: 72,
-                    color: theme.colorScheme.primary,
-                  ),
-                  const SizedBox(height: 24),
-                  Text(
-                    'Pick-a-Recipe',
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
+          child: SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 32,
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Icon(
+                      Icons.restaurant_menu,
+                      size: 64,
+                      color: theme.colorScheme.primary,
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Sign in with your Authentik account to reach your recipes.',
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                  const SizedBox(height: 32),
-                  if (auth.errorMessage != null) ...<Widget>[
-                    _ErrorBanner(message: auth.errorMessage!),
-                    const SizedBox(height: 16),
-                  ],
-                  FilledButton.icon(
-                    onPressed: auth.isBusy
-                        ? null
-                        : () => ref
-                            .read(authControllerProvider.notifier)
-                            .signIn(),
-                    icon: auth.isBusy
-                        ? const SizedBox.square(
-                            dimension: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.login),
-                    label: Text(
-                      auth.isBusy
-                          ? 'Waiting for browser\u2026'
-                          : 'Sign in with Authentik',
-                    ),
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                    ),
-                  ),
-                  if (auth.isBusy) ...<Widget>[
-                    const SizedBox(height: 12),
+                    const SizedBox(height: 20),
                     Text(
-                      'Finish signing in, in the browser that just opened.',
+                      'Pick-a-Recipe',
                       textAlign: TextAlign.center,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+                      style: theme.textTheme.headlineMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
+                    const SizedBox(height: 24),
+                    if (server.baseUrl == null)
+                      const _ServerForm()
+                    else
+                      const _SignInStep(),
                   ],
-                ],
+                ),
               ),
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Step one: where the instance lives.
+class _ServerForm extends ConsumerStatefulWidget {
+  const _ServerForm();
+
+  @override
+  ConsumerState<_ServerForm> createState() => _ServerFormState();
+}
+
+class _ServerFormState extends ConsumerState<_ServerForm> {
+  late final TextEditingController _address = TextEditingController(
+    text: ref.read(serverControllerProvider).suggestedUrl ?? '',
+  );
+
+  @override
+  void dispose() {
+    _address.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    ref.read(serverControllerProvider.notifier).connect(_address.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ServerState server = ref.watch(serverControllerProvider);
+    final ThemeData theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(
+          'Enter the address of your Pick-a-Recipe server.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 24),
+        if (server.errorMessage != null) ...<Widget>[
+          _ErrorBanner(message: server.errorMessage!),
+          const SizedBox(height: 16),
+        ],
+        TextField(
+          controller: _address,
+          enabled: !server.isBusy,
+          autofocus: true,
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+          textCapitalization: TextCapitalization.none,
+          textInputAction: TextInputAction.go,
+          onSubmitted: (_) => _submit(),
+          decoration: const InputDecoration(
+            labelText: 'Server address',
+            hintText: 'recipes.example.com',
+            prefixIcon: Icon(Icons.dns_outlined),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Https is assumed unless you type it. Include the port if it is not '
+          'the default, for example http://192.168.1.10:5006.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 20),
+        _BusyButton(
+          isBusy: server.isBusy,
+          busyLabel: 'Checking\u2026',
+          label: 'Connect',
+          icon: Icons.arrow_forward,
+          onPressed: _submit,
+        ),
+      ],
+    );
+  }
+}
+
+/// Step two: whichever way in this server actually offers.
+class _SignInStep extends ConsumerWidget {
+  const _SignInStep();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ServerState server = ref.watch(serverControllerProvider);
+    final AuthState auth = ref.watch(authControllerProvider);
+    final String baseUrl = server.baseUrl!;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _ServerChip(baseUrl: baseUrl, isBusy: server.isBusy || auth.isBusy),
+        const SizedBox(height: 20),
+        if (server.isBusy && server.status == null)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator()),
+          )
+        else
+          ..._body(context, ref, server, auth),
+      ],
+    );
+  }
+
+  List<Widget> _body(
+    BuildContext context,
+    WidgetRef ref,
+    ServerState server,
+    AuthState auth,
+  ) {
+    final ServerAuthStatus? status = server.status;
+
+    // Reachable-but-not-answering: keep the address and offer a retry, since
+    // an instance being briefly down is not a reason to re-type it.
+    if (status == null) {
+      return <Widget>[
+        _ErrorBanner(
+          message: server.errorMessage ?? 'Could not reach that server.',
+        ),
+        const SizedBox(height: 16),
+        _BusyButton(
+          isBusy: server.isBusy,
+          busyLabel: 'Retrying\u2026',
+          label: 'Try again',
+          icon: Icons.refresh,
+          onPressed: () =>
+              ref.read(serverControllerProvider.notifier).recheck(),
+        ),
+      ];
+    }
+
+    if (!status.mobileAuthEnabled) {
+      return <Widget>[
+        const _NoticeCard(
+          icon: Icons.phonelink_lock_outlined,
+          message: 'This server has app sign-in switched off. Whoever runs it '
+              'needs to set JWT_SECRET_KEY and restart.',
+        ),
+      ];
+    }
+
+    if (status.setupRequired) {
+      return <Widget>[
+        const _NoticeCard(
+          icon: Icons.person_add_alt,
+          message: 'This server has no account yet. Open it in a browser to '
+              'create the first one, then come back.',
+        ),
+        const SizedBox(height: 16),
+        OutlinedButton.icon(
+          onPressed: () => ref.read(urlLauncherProvider)(
+            Uri.parse('${server.baseUrl}/setup'),
+          ),
+          icon: const Icon(Icons.open_in_new),
+          label: const Text('Open setup in browser'),
+        ),
+        const SizedBox(height: 12),
+        _BusyButton(
+          isBusy: server.isBusy,
+          busyLabel: 'Checking\u2026',
+          label: 'I have created it',
+          icon: Icons.refresh,
+          onPressed: () =>
+              ref.read(serverControllerProvider.notifier).recheck(),
+        ),
+      ];
+    }
+
+    if (status.localAuthEnabled) {
+      return <Widget>[_PasswordForm(baseUrl: server.baseUrl!)];
+    }
+
+    if (status.ssoEnabled) {
+      return <Widget>[
+        _Blurb(
+          text: 'Sign in with your Authentik account to reach your recipes.',
+        ),
+        const SizedBox(height: 24),
+        if (auth.errorMessage != null) ...<Widget>[
+          _ErrorBanner(message: auth.errorMessage!),
+          const SizedBox(height: 16),
+        ],
+        _BusyButton(
+          isBusy: auth.isBusy,
+          busyLabel: 'Waiting for browser\u2026',
+          label: 'Sign in with Authentik',
+          icon: Icons.login,
+          onPressed: () =>
+              ref.read(authControllerProvider.notifier).signIn(),
+        ),
+        if (auth.isBusy) ...<Widget>[
+          const SizedBox(height: 12),
+          _Blurb(
+            text: 'Finish signing in, in the browser that just opened.',
+            small: true,
+          ),
+        ],
+      ];
+    }
+
+    // AUTH_MODE=authentik with no client credentials configured: the server
+    // fails closed, and there is nothing the app can offer.
+    return <Widget>[
+      const _NoticeCard(
+        icon: Icons.report_gmailerrorred_outlined,
+        message: 'This server has no way to sign in configured. Whoever runs '
+            'it needs to finish setting up Authentik, or switch to local '
+            'accounts.',
+      ),
+    ];
+  }
+}
+
+class _PasswordForm extends ConsumerStatefulWidget {
+  const _PasswordForm({required this.baseUrl});
+
+  final String baseUrl;
+
+  @override
+  ConsumerState<_PasswordForm> createState() => _PasswordFormState();
+}
+
+class _PasswordFormState extends ConsumerState<_PasswordForm> {
+  final TextEditingController _username = TextEditingController();
+  final TextEditingController _password = TextEditingController();
+  bool _obscured = true;
+
+  @override
+  void dispose() {
+    _username.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    ref.read(authControllerProvider.notifier).signInWithPassword(
+          username: _username.text.trim(),
+          password: _password.text,
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AuthState auth = ref.watch(authControllerProvider);
+    final bool filled =
+        _username.text.trim().isNotEmpty && _password.text.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        if (isInsecureServerUrl(widget.baseUrl)) ...<Widget>[
+          const _NoticeCard(
+            icon: Icons.lock_open_outlined,
+            message: 'This server uses plain http, so your password travels '
+                'unencrypted. Fine on a network you trust; avoid it over the '
+                'internet.',
+          ),
+          const SizedBox(height: 16),
+        ],
+        if (auth.errorMessage != null) ...<Widget>[
+          _ErrorBanner(message: auth.errorMessage!),
+          const SizedBox(height: 16),
+        ],
+        TextField(
+          controller: _username,
+          enabled: !auth.isBusy,
+          autofocus: true,
+          autocorrect: false,
+          textCapitalization: TextCapitalization.none,
+          textInputAction: TextInputAction.next,
+          onChanged: (_) => setState(() {}),
+          decoration: const InputDecoration(
+            labelText: 'Username',
+            prefixIcon: Icon(Icons.person_outline),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _password,
+          enabled: !auth.isBusy,
+          obscureText: _obscured,
+          textInputAction: TextInputAction.go,
+          onChanged: (_) => setState(() {}),
+          onSubmitted: (_) => filled ? _submit() : null,
+          decoration: InputDecoration(
+            labelText: 'Password',
+            prefixIcon: const Icon(Icons.lock_outline),
+            border: const OutlineInputBorder(),
+            suffixIcon: IconButton(
+              onPressed: () => setState(() => _obscured = !_obscured),
+              icon: Icon(
+                _obscured ? Icons.visibility_off : Icons.visibility,
+              ),
+              tooltip: _obscured ? 'Show password' : 'Hide password',
+            ),
+          ),
+        ),
+        const SizedBox(height: 20),
+        _BusyButton(
+          isBusy: auth.isBusy,
+          busyLabel: 'Signing in\u2026',
+          label: 'Sign in',
+          icon: Icons.login,
+          onPressed: filled ? _submit : null,
+        ),
+      ],
+    );
+  }
+}
+
+/// The current address, with the way back to the address form.
+class _ServerChip extends ConsumerWidget {
+  const _ServerChip({required this.baseUrl, required this.isBusy});
+
+  final String baseUrl;
+  final bool isBusy;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+
+    return Row(
+      children: <Widget>[
+        Icon(
+          isInsecureServerUrl(baseUrl) ? Icons.lock_open : Icons.lock_outline,
+          size: 16,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            baseUrl.replaceFirst(RegExp(r'^https?://'), ''),
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        TextButton(
+          onPressed: isBusy
+              ? null
+              : () => ref.read(serverControllerProvider.notifier).forget(),
+          child: const Text('Change'),
+        ),
+      ],
+    );
+  }
+}
+
+class _Blurb extends StatelessWidget {
+  const _Blurb({required this.text, this.small = false});
+
+  final String text;
+  final bool small;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Text(
+      text,
+      textAlign: TextAlign.center,
+      style: (small ? theme.textTheme.bodySmall : theme.textTheme.bodyMedium)
+          ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+    );
+  }
+}
+
+class _BusyButton extends StatelessWidget {
+  const _BusyButton({
+    required this.isBusy,
+    required this.busyLabel,
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final bool isBusy;
+  final String busyLabel;
+  final String label;
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: isBusy ? null : onPressed,
+      icon: isBusy
+          ? const SizedBox.square(
+              dimension: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Icon(icon),
+      label: Text(isBusy ? busyLabel : label),
+      style: FilledButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+      ),
+    );
+  }
+}
+
+/// Something the user cannot act on from here, phrased so they know who can.
+class _NoticeCard extends StatelessWidget {
+  const _NoticeCard({required this.icon, required this.message});
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, color: colors.onSurfaceVariant, size: 20),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: colors.onSurfaceVariant),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/src/features/auth/server_controller.dart
+++ b/mobile/lib/src/features/auth/server_controller.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/providers.dart';
+import '../../core/server_store.dart';
+import 'auth_repository.dart';
+import 'server_repository.dart';
+import 'server_state.dart';
+
+/// Owns the server address: reads the saved one at startup, verifies a new one
+/// before saving it, and forgets it on request.
+class ServerController extends Notifier<ServerState> {
+  @override
+  ServerState build() => ServerState(
+        suggestedUrl: ref.read(configProvider).suggestedServerUrl,
+      );
+
+  ServerStore get _store => ref.read(serverStoreProvider);
+  ServerRepository get _servers => ref.read(serverRepositoryProvider);
+
+  /// Loads the saved address and asks it how to sign in.
+  ///
+  /// Returns the address if one is saved, whether or not it answered: an
+  /// instance that is merely down should not make the app forget where it is.
+  Future<String?> restore() async {
+    final String? saved = await _store.read();
+    if (saved == null) {
+      state = state.copyWith(isBusy: false);
+      return null;
+    }
+
+    state = ServerState(
+      baseUrl: saved,
+      isBusy: true,
+      suggestedUrl: state.suggestedUrl,
+    );
+    try {
+      final ServerAuthStatus status = await _servers.statusOf(saved);
+      state = ServerState(
+        baseUrl: saved,
+        status: status,
+        suggestedUrl: state.suggestedUrl,
+      );
+    } on AuthApiException catch (error) {
+      state = ServerState(
+        baseUrl: saved,
+        isBusy: false,
+        errorMessage: error.message,
+        suggestedUrl: state.suggestedUrl,
+      );
+    }
+    return saved;
+  }
+
+  /// Verifies what the user typed, then keeps it.
+  ///
+  /// Nothing is saved until the address answers, so a typo does not leave the
+  /// app pointing somewhere it can never reach.
+  Future<bool> connect(String input) async {
+    if (state.isBusy) return false;
+
+    final String? candidate = normaliseServerUrl(input);
+    if (candidate == null) {
+      state = state.copyWith(
+        errorMessage: 'That does not look like a web address. Something like '
+            'recipes.example.com, or http://192.168.1.10:5006.',
+      );
+      return false;
+    }
+
+    state = state.copyWith(isBusy: true);
+    try {
+      final ServerAuthStatus status = await _servers.statusOf(candidate);
+      await _store.save(candidate);
+      state = ServerState(
+        baseUrl: candidate,
+        status: status,
+        suggestedUrl: state.suggestedUrl,
+      );
+      return true;
+    } on AuthApiException catch (error) {
+      state = state.copyWith(isBusy: false, errorMessage: error.message);
+      return false;
+    }
+  }
+
+  /// Re-asks the current server, for the retry button after it was unreachable.
+  Future<void> recheck() async {
+    final String? current = state.baseUrl;
+    if (current == null || state.isBusy) return;
+
+    state = state.copyWith(isBusy: true);
+    try {
+      final ServerAuthStatus status = await _servers.statusOf(current);
+      state = ServerState(
+        baseUrl: current,
+        status: status,
+        suggestedUrl: state.suggestedUrl,
+      );
+    } on AuthApiException catch (error) {
+      state = state.copyWith(isBusy: false, errorMessage: error.message);
+    }
+  }
+
+  /// Forgets the address so another can be entered.
+  ///
+  /// Tokens go with it: they were issued by the old server and mean nothing to
+  /// a different one, and leaving them behind would attach a stranger's bearer
+  /// token to the next instance's requests.
+  Future<void> forget() async {
+    await _store.clear();
+    await ref.read(tokenStoreProvider).clear();
+    state = ServerState(suggestedUrl: state.suggestedUrl);
+  }
+
+  void dismissError() {
+    if (state.errorMessage == null) return;
+    state = state.copyWith();
+  }
+}
+
+final NotifierProvider<ServerController, ServerState> serverControllerProvider =
+    NotifierProvider<ServerController, ServerState>(ServerController.new);

--- a/mobile/lib/src/features/auth/server_repository.dart
+++ b/mobile/lib/src/features/auth/server_repository.dart
@@ -1,0 +1,83 @@
+import 'package:dio/dio.dart';
+
+import '../../core/api_client.dart';
+import 'auth_repository.dart';
+
+/// Builds a client for an address that is not the configured one yet.
+///
+/// Separate from the app's main Dio on purpose: a candidate address must be
+/// checked before it is saved, and doing that on the shared client would leave
+/// it pointing somewhere unverified if the check failed.
+typedef ProbeClientFactory = Dio Function(String baseUrl);
+
+Dio createProbeClient(String baseUrl) {
+  return Dio(
+    BaseOptions(
+      baseUrl: baseUrl,
+      // Shorter than the app's: this runs with somebody watching a spinner
+      // after typing an address, and a wrong one is the common case.
+      connectTimeout: const Duration(seconds: 8),
+      receiveTimeout: const Duration(seconds: 8),
+    ),
+  );
+}
+
+class ServerRepository {
+  const ServerRepository(this._newClient);
+
+  final ProbeClientFactory _newClient;
+
+  /// Asks an address how it wants to be signed into.
+  ///
+  /// Doubles as the check that the address is a Pick-a-Recipe server at all,
+  /// which is why the failure messages talk about the address rather than about
+  /// authentication.
+  Future<ServerAuthStatus> statusOf(String baseUrl) async {
+    final Dio client = _newClient(baseUrl);
+    try {
+      final Response<Map<String, dynamic>> response =
+          await client.get<Map<String, dynamic>>(kAuthStatusPath);
+      final Map<String, dynamic>? body = response.data;
+      // A reachable host that answers with something else — a router login
+      // page, an unrelated app — is not this server.
+      if (body == null || !body.containsKey('sso_enabled')) {
+        throw const AuthApiException(
+          'That address answered, but not like a Pick-a-Recipe server. '
+          'Check the address and port.',
+        );
+      }
+      return ServerAuthStatus.fromJson(body);
+    } on DioException catch (error) {
+      throw AuthApiException(_describe(error, baseUrl));
+    } finally {
+      client.close();
+    }
+  }
+
+  String _describe(DioException error, String baseUrl) {
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        return 'No answer from $baseUrl. Check the address, and that your '
+            'phone can reach it from this network.';
+      case DioExceptionType.badCertificate:
+        return 'The HTTPS certificate at $baseUrl was rejected. A self-signed '
+            'certificate will not work; use a trusted one, or plain http on a '
+            'network you trust.';
+      case DioExceptionType.connectionError:
+        return 'Could not reach $baseUrl. Check the address and your '
+            'connection.';
+      case DioExceptionType.badResponse:
+        final int? status = error.response?.statusCode;
+        if (status == 404) {
+          return 'Reached $baseUrl, but it has no Pick-a-Recipe API. Check '
+              'whether the address needs a path or a different port.';
+        }
+        return 'The server at $baseUrl answered with an error ($status).';
+      default:
+        return 'Could not reach $baseUrl. Check the address and your '
+            'connection.';
+    }
+  }
+}

--- a/mobile/lib/src/features/auth/server_state.dart
+++ b/mobile/lib/src/features/auth/server_state.dart
@@ -1,0 +1,51 @@
+import 'auth_repository.dart';
+
+/// Which instance the app points at, and what it said about signing in.
+///
+/// Kept apart from AuthState because the two answer different questions and
+/// change at different times: this one survives sign-out, since the address is
+/// still right after a session ends.
+class ServerState {
+  const ServerState({
+    this.baseUrl,
+    this.status,
+    this.isBusy = false,
+    this.errorMessage,
+    this.suggestedUrl,
+  });
+
+  /// Normalised base URL, or null when none has been chosen yet.
+  final String? baseUrl;
+
+  /// Null until the address has been reached — including when [baseUrl] is set
+  /// but the server was unreachable on this launch.
+  final ServerAuthStatus? status;
+
+  final bool isBusy;
+  final String? errorMessage;
+
+  /// Prefills the address field. Only set for dev builds.
+  final String? suggestedUrl;
+
+  /// True once there is an address that answered, which is the only state where
+  /// a sign-in form can be shown.
+  bool get isReady => baseUrl != null && status != null;
+
+  ServerState copyWith({
+    String? baseUrl,
+    ServerAuthStatus? status,
+    bool? isBusy,
+    String? errorMessage,
+    String? suggestedUrl,
+  }) {
+    return ServerState(
+      baseUrl: baseUrl ?? this.baseUrl,
+      status: status ?? this.status,
+      isBusy: isBusy ?? this.isBusy,
+      // Passing null clears the message, which copyWith's usual ?? idiom
+      // cannot express.
+      errorMessage: errorMessage,
+      suggestedUrl: suggestedUrl ?? this.suggestedUrl,
+    );
+  }
+}

--- a/mobile/test/app_config_test.dart
+++ b/mobile/test/app_config_test.dart
@@ -3,23 +3,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pickarecipe/src/config/app_config.dart';
 
 void main() {
-  test('prod flavor resolves to the production host', () {
+  test('release builds suggest no server, since they cannot know one', () {
     const config = AppConfig(flavor: 'prod');
-    expect(config.baseUrl, 'https://recipes.pickel.me');
+    expect(config.suggestedServerUrl, isNull);
     expect(config.isProd, isTrue);
   });
 
-  test('dev flavor resolves to the emulator loopback alias', () {
+  test('dev builds prefill the emulator loopback alias', () {
     const config = AppConfig(flavor: 'dev');
-    expect(config.baseUrl, 'http://10.0.2.2:5006');
+    expect(config.suggestedServerUrl, 'http://10.0.2.2:5006');
     expect(config.isProd, isFalse);
   });
 
-  test('explicit override wins over flavor defaults', () {
+  test('an explicit override prefills either flavor', () {
     const config = AppConfig(
       flavor: 'prod',
       apiBaseUrlOverride: 'https://staging.example.com',
     );
-    expect(config.baseUrl, 'https://staging.example.com');
+    expect(config.suggestedServerUrl, 'https://staging.example.com');
   });
 }

--- a/mobile/test/auth_controller_test.dart
+++ b/mobile/test/auth_controller_test.dart
@@ -18,12 +18,11 @@ void main() {
     launched = <Uri>[];
   });
 
-  /// Builds a container wired to canned HTTP replies and a recording launcher.
-  ProviderContainer harness(
-    Map<String, List<FakeReply>> replies, {
+  /// Builds a container wired to a fake transport and a recording launcher.
+  ProviderContainer harnessWith(
+    FakeAdapter adapter, {
     bool launchSucceeds = true,
   }) {
-    final FakeAdapter adapter = FakeAdapter(replies);
     final ProviderContainer container = ProviderContainer(
       overrides: [
         secureStoreProvider.overrideWithValue(secureStore),
@@ -44,6 +43,13 @@ void main() {
     );
     addTearDown(container.dispose);
     return container;
+  }
+
+  ProviderContainer harness(
+    Map<String, List<FakeReply>> replies, {
+    bool launchSucceeds = true,
+  }) {
+    return harnessWith(FakeAdapter(replies), launchSucceeds: launchSucceeds);
   }
 
   AuthController controllerOf(ProviderContainer c) =>
@@ -130,6 +136,141 @@ void main() {
       await controllerOf(c).signIn();
 
       expect(launched, hasLength(1));
+    });
+  });
+
+  group('signInWithPassword', () {
+    test('stores the pair the server returns and adopts the identity',
+        () async {
+      // No browser and no deep link on this path: the server hands the tokens
+      // straight back, so sign-in completes in one call.
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kPasswordLoginPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'access_token': 'a1',
+            'refresh_token': 'r1',
+          }),
+        ],
+        kMobileMePath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'username': 'ada',
+            'is_admin': false,
+          }),
+        ],
+      });
+
+      await controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'correct horse battery',
+      );
+
+      final AuthState state = stateOf(c);
+      expect(state.status, AuthStatus.signedIn);
+      expect(state.username, 'ada');
+      expect(state.isAdmin, isFalse);
+      expect(launched, isEmpty);
+      final AuthTokens? stored = await c.read(tokenStoreProvider).read();
+      expect(stored?.refreshToken, 'r1');
+    });
+
+    test('shows the rejection and stores nothing', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kPasswordLoginPath: <FakeReply>[
+          const FakeReply(401, <String, dynamic>{
+            'error': 'Incorrect username or password.',
+          }),
+        ],
+      });
+
+      await controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'wrong',
+      );
+
+      expect(stateOf(c).status, AuthStatus.signedOut);
+      expect(stateOf(c).isBusy, isFalse);
+      expect(stateOf(c).errorMessage, contains('Incorrect username'));
+      expect(secureStore.values, isEmpty);
+    });
+
+    test('passes the throttle message through verbatim', () async {
+      // The wait is the useful part; a generic "try again" would leave the user
+      // tapping.
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kPasswordLoginPath: <FakeReply>[
+          const FakeReply(429, <String, dynamic>{
+            'error': 'Too many attempts. Try again in 8 seconds.',
+          }),
+        ],
+      });
+
+      await controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'wrong',
+      );
+
+      expect(stateOf(c).errorMessage, contains('8 seconds'));
+    });
+
+    test('explains a server that only does single sign-on', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kPasswordLoginPath: <FakeReply>[
+          const FakeReply(400, <String, dynamic>{
+            'error': 'This server uses single sign-on. Sign in with Authentik.',
+          }),
+        ],
+      });
+
+      await controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'whatever',
+      );
+
+      expect(stateOf(c).errorMessage, contains('single sign-on'));
+    });
+
+    test('discards a pair the server will not then vouch for', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kPasswordLoginPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'access_token': 'a1',
+            'refresh_token': 'r1',
+          }),
+        ],
+        kMobileMePath: <FakeReply>[const FakeReply(401)],
+        kRefreshPath: <FakeReply>[const FakeReply(401)],
+      });
+
+      await controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'correct horse battery',
+      );
+
+      expect(stateOf(c).status, AuthStatus.signedOut);
+      expect(await c.read(tokenStoreProvider).read(), isNull);
+    });
+
+    test('a second submit while busy does not send a second attempt', () async {
+      // Otherwise a double tap spends two entries on the server's throttle
+      // ladder for one intended sign-in.
+      final FakeAdapter adapter = FakeAdapter(<String, List<FakeReply>>{
+        kPasswordLoginPath: <FakeReply>[
+          const FakeReply(401, <String, dynamic>{'error': 'nope'}),
+        ],
+      });
+      final ProviderContainer c = harnessWith(adapter);
+
+      final Future<void> first = controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'wrong',
+      );
+      final Future<void> second = controllerOf(c).signInWithPassword(
+        username: 'ada',
+        password: 'wrong',
+      );
+      await Future.wait(<Future<void>>[first, second]);
+
+      expect(adapter.callsTo(kPasswordLoginPath), 1);
     });
   });
 

--- a/mobile/test/server_controller_test.dart
+++ b/mobile/test/server_controller_test.dart
@@ -1,0 +1,253 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickarecipe/src/config/app_config.dart';
+import 'package:pickarecipe/src/core/api_client.dart';
+import 'package:pickarecipe/src/core/providers.dart';
+import 'package:pickarecipe/src/core/token_store.dart';
+import 'package:pickarecipe/src/features/auth/server_controller.dart';
+import 'package:pickarecipe/src/features/auth/server_state.dart';
+
+import 'support/fakes.dart';
+
+/// A server running local accounts, with app sign-in enabled.
+const Map<String, dynamic> _localReady = <String, dynamic>{
+  'auth_mode': 'local',
+  'local_auth_enabled': true,
+  'sso_enabled': false,
+  'setup_required': false,
+  'mobile_auth_enabled': true,
+};
+
+void main() {
+  late FakeSecureStore secureStore;
+  late List<String> probed;
+
+  setUp(() {
+    secureStore = FakeSecureStore();
+    probed = <String>[];
+  });
+
+  /// Wires the probe client to canned replies and records which addresses were
+  /// asked, so tests can assert that nothing unexpected was contacted.
+  ProviderContainer harness(
+    Map<String, List<FakeReply>> replies, {
+    String? suggested,
+    DioException? failWith,
+  }) {
+    final ProviderContainer container = ProviderContainer(
+      overrides: [
+        secureStoreProvider.overrideWithValue(secureStore),
+        configProvider.overrideWithValue(
+          AppConfig(flavor: 'prod', apiBaseUrlOverride: suggested),
+        ),
+        probeClientFactoryProvider.overrideWithValue((String baseUrl) {
+          probed.add(baseUrl);
+          final Dio dio = Dio(BaseOptions(baseUrl: baseUrl));
+          dio.httpClientAdapter = failWith != null
+              ? ThrowingAdapter(failWith)
+              : FakeAdapter(replies);
+          return dio;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  ServerController controllerOf(ProviderContainer c) =>
+      c.read(serverControllerProvider.notifier);
+  ServerState stateOf(ProviderContainer c) => c.read(serverControllerProvider);
+
+  group('connect', () {
+    test('normalises what was typed before contacting anything', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[const FakeReply(200, _localReady)],
+      });
+
+      expect(await controllerOf(c).connect('  recipes.example.com/  '), isTrue);
+
+      expect(probed.single, 'https://recipes.example.com');
+      expect(stateOf(c).baseUrl, 'https://recipes.example.com');
+      expect(await secureStore.read('server.base_url'),
+          'https://recipes.example.com');
+    });
+
+    test('adopts what the server said about signing in', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{
+            'sso_enabled': true,
+            'local_auth_enabled': false,
+            'setup_required': false,
+            'mobile_auth_enabled': true,
+          }),
+        ],
+      });
+
+      await controllerOf(c).connect('recipes.example.com');
+
+      final ServerState state = stateOf(c);
+      expect(state.isReady, isTrue);
+      expect(state.status!.ssoEnabled, isTrue);
+      expect(state.status!.localAuthEnabled, isFalse);
+    });
+
+    test('explains input that is not an address, and contacts nothing',
+        () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{});
+
+      expect(await controllerOf(c).connect('not a url at all'), isFalse);
+
+      expect(probed, isEmpty);
+      expect(stateOf(c).baseUrl, isNull);
+      expect(stateOf(c).errorMessage, contains('web address'));
+    });
+
+    test('saves nothing when the address cannot be reached', () async {
+      // Otherwise a typo would strand the app on an address it can never reach,
+      // with no form left on screen to correct it.
+      final ProviderContainer c = harness(
+        <String, List<FakeReply>>{},
+        failWith: DioException.connectionError(
+          requestOptions: RequestOptions(path: kAuthStatusPath),
+          reason: 'no route to host',
+        ),
+      );
+
+      expect(await controllerOf(c).connect('recipes.example.com'), isFalse);
+
+      expect(stateOf(c).baseUrl, isNull);
+      expect(await secureStore.read('server.base_url'), isNull);
+      expect(stateOf(c).errorMessage, contains('recipes.example.com'));
+    });
+
+    test('rejects a host that answers with something else', () async {
+      // A router admin page or an unrelated app on that port: reachable, but
+      // not this server, and every later request would fail confusingly.
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[
+          const FakeReply(200, <String, dynamic>{'hello': 'world'}),
+        ],
+      });
+
+      expect(await controllerOf(c).connect('recipes.example.com'), isFalse);
+
+      expect(stateOf(c).baseUrl, isNull);
+      expect(stateOf(c).errorMessage, contains('not like a Pick-a-Recipe'));
+    });
+
+    test('a 404 points at the address rather than at authentication', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[const FakeReply(404)],
+      });
+
+      await controllerOf(c).connect('example.com');
+
+      expect(stateOf(c).errorMessage, contains('no Pick-a-Recipe API'));
+    });
+  });
+
+  group('restore', () {
+    test('loads the saved address and re-reads its status', () async {
+      await secureStore.write('server.base_url', 'https://recipes.example.com');
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[const FakeReply(200, _localReady)],
+      });
+
+      expect(await controllerOf(c).restore(), 'https://recipes.example.com');
+
+      expect(stateOf(c).isReady, isTrue);
+      expect(stateOf(c).status!.localAuthEnabled, isTrue);
+    });
+
+    test('keeps the address when the server is merely down', () async {
+      // An instance being unreachable on one launch is not a reason to make
+      // somebody type its address again.
+      await secureStore.write('server.base_url', 'https://recipes.example.com');
+      final ProviderContainer c = harness(
+        <String, List<FakeReply>>{},
+        failWith: DioException.connectionTimeout(
+          timeout: const Duration(seconds: 8),
+          requestOptions: RequestOptions(path: kAuthStatusPath),
+        ),
+      );
+
+      expect(await controllerOf(c).restore(), 'https://recipes.example.com');
+
+      final ServerState state = stateOf(c);
+      expect(state.baseUrl, 'https://recipes.example.com');
+      expect(state.status, isNull);
+      expect(state.isReady, isFalse);
+      expect(state.errorMessage, isNotNull);
+    });
+
+    test('reports no address on a fresh install', () async {
+      final ProviderContainer c = harness(<String, List<FakeReply>>{});
+
+      expect(await controllerOf(c).restore(), isNull);
+
+      expect(probed, isEmpty);
+      expect(stateOf(c).baseUrl, isNull);
+    });
+  });
+
+  group('recheck', () {
+    test('picks up a server that has come back', () async {
+      await secureStore.write('server.base_url', 'https://recipes.example.com');
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[
+          const FakeReply(503),
+          const FakeReply(200, _localReady),
+        ],
+      });
+
+      await controllerOf(c).restore();
+      expect(stateOf(c).isReady, isFalse);
+
+      await controllerOf(c).recheck();
+
+      expect(stateOf(c).isReady, isTrue);
+      expect(stateOf(c).errorMessage, isNull);
+    });
+  });
+
+  group('forget', () {
+    test('drops the address and the tokens issued by it', () async {
+      // Tokens are only meaningful to the server that minted them; carrying
+      // them to a different instance would attach a stranger's bearer token to
+      // its requests.
+      await secureStore.write('server.base_url', 'https://recipes.example.com');
+      final ProviderContainer c = harness(<String, List<FakeReply>>{
+        kAuthStatusPath: <FakeReply>[const FakeReply(200, _localReady)],
+      });
+      await c.read(tokenStoreProvider).save(
+            const AuthTokens(accessToken: 'a', refreshToken: 'r'),
+          );
+      await controllerOf(c).restore();
+
+      await controllerOf(c).forget();
+
+      expect(stateOf(c).baseUrl, isNull);
+      expect(stateOf(c).status, isNull);
+      expect(await c.read(tokenStoreProvider).read(), isNull);
+      expect(await secureStore.read('server.base_url'), isNull);
+    });
+  });
+
+  group('suggestedUrl', () {
+    test('carries the dev prefill through, and survives a failed connect',
+        () async {
+      final ProviderContainer c = harness(
+        <String, List<FakeReply>>{},
+        suggested: 'http://10.0.2.2:5006',
+      );
+
+      expect(stateOf(c).suggestedUrl, 'http://10.0.2.2:5006');
+
+      await controllerOf(c).connect('nonsense');
+
+      expect(stateOf(c).suggestedUrl, 'http://10.0.2.2:5006');
+    });
+  });
+}

--- a/mobile/test/server_store_test.dart
+++ b/mobile/test/server_store_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pickarecipe/src/core/server_store.dart';
+
+import 'support/fakes.dart';
+
+void main() {
+  group('normaliseServerUrl', () {
+    test('assumes https for a bare host, rather than http', () {
+      // Defaulting the other way would put a password on the wire in clear for
+      // anyone who types the short form, which is most people.
+      expect(normaliseServerUrl('recipes.example.com'),
+          'https://recipes.example.com');
+    });
+
+    test('keeps an explicit scheme, including plain http', () {
+      expect(normaliseServerUrl('http://192.168.1.10:5006'),
+          'http://192.168.1.10:5006');
+    });
+
+    test('trims surrounding whitespace from a paste', () {
+      expect(normaliseServerUrl('  https://recipes.example.com  '),
+          'https://recipes.example.com');
+    });
+
+    test('drops a trailing slash that would double up on every path', () {
+      expect(normaliseServerUrl('https://recipes.example.com/'),
+          'https://recipes.example.com');
+      expect(normaliseServerUrl('https://example.com/recipes///'),
+          'https://example.com/recipes');
+    });
+
+    test('keeps a port and a subpath', () {
+      expect(normaliseServerUrl('example.com:8443/recipes'),
+          'https://example.com:8443/recipes');
+    });
+
+    test('discards a query and fragment, which a base URL cannot carry', () {
+      expect(normaliseServerUrl('https://example.com/app?tab=1#top'),
+          'https://example.com/app');
+    });
+
+    test('accepts an IPv6 literal, brackets and all', () {
+      expect(normaliseServerUrl('http://[::1]:5006'), 'http://[::1]:5006');
+    });
+
+    test('drops credentials smuggled into the address', () {
+      expect(normaliseServerUrl('https://bob:hunter2@example.com'),
+          'https://example.com');
+    });
+
+    test('refuses input that is not a web address', () {
+      expect(normaliseServerUrl(''), isNull);
+      expect(normaliseServerUrl('   '), isNull);
+      expect(normaliseServerUrl('ftp://example.com'), isNull);
+      expect(normaliseServerUrl('javascript://example.com'), isNull);
+      expect(normaliseServerUrl('https://'), isNull);
+      expect(normaliseServerUrl('where are my recipes'), isNull);
+    });
+  });
+
+  group('isInsecureServerUrl', () {
+    test('flags http and not https', () {
+      expect(isInsecureServerUrl('http://192.168.1.10:5006'), isTrue);
+      expect(isInsecureServerUrl('https://recipes.example.com'), isFalse);
+    });
+  });
+
+  group('ServerStore', () {
+    test('round-trips the address and clears it', () async {
+      final FakeSecureStore backing = FakeSecureStore();
+      final ServerStore store = ServerStore(backing);
+
+      expect(await store.read(), isNull);
+
+      await store.save('https://recipes.example.com');
+      expect(await store.read(), 'https://recipes.example.com');
+
+      await store.clear();
+      expect(await store.read(), isNull);
+    });
+
+    test('treats an empty stored value as none', () async {
+      final FakeSecureStore backing = FakeSecureStore();
+      backing.values['server.base_url'] = '';
+
+      expect(await ServerStore(backing).read(), isNull);
+    });
+  });
+}

--- a/mobile/test/support/fakes.dart
+++ b/mobile/test/support/fakes.dart
@@ -67,3 +67,23 @@ class FakeAdapter implements HttpClientAdapter {
   @override
   void close({bool force = false}) {}
 }
+
+/// Adapter that fails every request, for the transport errors a canned reply
+/// cannot express: unreachable hosts, timeouts, rejected certificates.
+class ThrowingAdapter implements HttpClientAdapter {
+  ThrowingAdapter(this._error);
+
+  final DioException _error;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    throw _error;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/tests/test_mobile_password_login.py
+++ b/tests/test_mobile_password_login.py
@@ -1,0 +1,275 @@
+"""Tests for app sign-in with a local username and password.
+
+The Android app is installed by people running their own instances, so it has to
+work against a server with no identity provider. This covers the endpoint that
+makes that possible, and the ways it must refuse.
+
+Forked-interpreter approach, as in test_local_auth: AUTH_MODE is fixed when
+`app` is imported, and both modes need exercising here.
+"""
+
+import os
+import sys
+import textwrap
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'ui'))
+
+from app_harness import result as _result, run as _run  # noqa: E402
+
+PASSWORD = 'a properly long passphrase'
+LOGIN = '/api/mobile/auth/login'
+SECRET = 'test-only-signing-key-of-adequate-length-0123456789'
+
+_PRELUDE = f"""
+    import database, login_throttle, mobile_auth, passwords
+    from app import app
+
+    PASSWORD = {PASSWORD!r}
+    LOGIN = {LOGIN!r}
+    app.config['TESTING'] = True
+
+    def hashed(password=PASSWORD):
+        return passwords.hash_password(password)
+
+    def login(username, password=PASSWORD, client=None):
+        return (client or app.test_client()).post(
+            LOGIN, json={{'username': username, 'password': password}})
+"""
+
+
+def _run_mobile(script: str, **env) -> dict:
+    env.setdefault('JWT_SECRET_KEY', SECRET)
+    combined = textwrap.dedent(_PRELUDE) + textwrap.dedent(script)
+    return _result(_run(combined, **env))
+
+
+class TestPasswordLogin(unittest.TestCase):
+    """The happy path, and the token pair it has to hand back."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_mobile("""
+            database.claim_first_local_admin('boss', hashed())
+            database.create_local_user('cook', hashed(), is_admin=False)
+
+            ok = login('boss')
+            body = ok.get_json()
+            access = mobile_auth.decode_token(body.get('access_token', ''),
+                                              expected_type='access')
+            refresh = mobile_auth.decode_token(body.get('refresh_token', ''),
+                                               expected_type='refresh')
+
+            # The token must actually open the app's endpoints, not merely decode.
+            me = app.test_client().get('/api/mobile/me', headers={
+                'Authorization': 'Bearer ' + body['access_token']})
+
+            plain = login('cook').get_json()
+            plain_claims = mobile_auth.decode_token(plain['access_token'],
+                                                   expected_type='access')
+
+            emit(
+                status=ok.status_code,
+                token_type=body.get('token_type'),
+                expires_in=body.get('expires_in'),
+                access_sub=access and access.get('sub'),
+                access_admin=access and access.get('adm'),
+                refresh_sub=refresh and refresh.get('sub'),
+                me_status=me.status_code,
+                me_user=me.get_json().get('username'),
+                me_admin=me.get_json().get('is_admin'),
+                plain_admin=plain_claims.get('adm'),
+            )
+        """)
+
+    def test_returns_a_usable_token_pair(self):
+        self.assertEqual(self.res['status'], 200)
+        self.assertEqual(self.res['token_type'], 'Bearer')
+        self.assertEqual(self.res['expires_in'], 900)
+        self.assertEqual(self.res['access_sub'], 'boss')
+        self.assertEqual(self.res['refresh_sub'], 'boss')
+
+    def test_the_token_opens_the_app_endpoints(self):
+        self.assertEqual(self.res['me_status'], 200)
+        self.assertEqual(self.res['me_user'], 'boss')
+        self.assertTrue(self.res['me_admin'])
+
+    def test_admin_rights_are_carried_and_not_invented(self):
+        self.assertTrue(self.res['access_admin'])
+        self.assertFalse(self.res['plain_admin'])
+
+
+class TestRefusals(unittest.TestCase):
+    """Wrong credentials, and the states where there is nothing to sign into."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_mobile("""
+            before_setup = login('boss')
+
+            database.claim_first_local_admin('boss', hashed())
+
+            wrong = login('boss', 'not the passphrase')
+            missing = login('ghost')
+            blank = app.test_client().post(LOGIN, json={})
+            not_json = app.test_client().post(LOGIN, data='username=boss')
+
+            emit(
+                before_setup_status=before_setup.status_code,
+                before_setup_flag=before_setup.get_json().get('setup_required'),
+                wrong_status=wrong.status_code,
+                wrong_error=wrong.get_json().get('error'),
+                missing_status=missing.status_code,
+                missing_error=missing.get_json().get('error'),
+                # Same wording either way, or the endpoint becomes a way to
+                # enumerate which accounts exist.
+                indistinguishable=(wrong.get_json().get('error')
+                                   == missing.get_json().get('error')),
+                wrong_has_no_token='access_token' not in wrong.get_json(),
+                blank_status=blank.status_code,
+                not_json_status=not_json.status_code,
+            )
+        """)
+
+    def test_before_setup_it_says_so_rather_than_rejecting_credentials(self):
+        # An empty instance is not a wrong password, and the app can act on the
+        # difference by sending the user to a browser.
+        self.assertEqual(self.res['before_setup_status'], 409)
+        self.assertTrue(self.res['before_setup_flag'])
+
+    def test_wrong_password_is_refused_without_a_token(self):
+        self.assertEqual(self.res['wrong_status'], 401)
+        self.assertTrue(self.res['wrong_has_no_token'])
+
+    def test_unknown_and_wrong_are_indistinguishable(self):
+        self.assertEqual(self.res['missing_status'], 401)
+        self.assertTrue(self.res['indistinguishable'])
+
+    def test_missing_and_malformed_bodies_are_refused(self):
+        self.assertEqual(self.res['blank_status'], 401)
+        self.assertEqual(self.res['not_json_status'], 401)
+
+
+class TestThrottling(unittest.TestCase):
+    """The app endpoint must not be a way around the form's rate limit."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_mobile("""
+            database.claim_first_local_admin('boss', hashed())
+            login_throttle.clear_all()
+
+            statuses = [login('boss', 'wrong').status_code for _ in range(5)]
+            throttled = login('boss', 'wrong')
+
+            # Shares the ladder with the browser form, keyed on (IP, username):
+            # otherwise an attacker throttled on one could just use the other.
+            form = app.test_client().post(
+                '/auth/local/login',
+                json={'username': 'boss', 'password': PASSWORD})
+
+            login_throttle.clear_all()
+            after_reset = login('boss')
+
+            emit(
+                statuses=statuses,
+                throttled_status=throttled.status_code,
+                retry_after=throttled.headers.get('Retry-After'),
+                throttled_error=throttled.get_json().get('error'),
+                form_status=form.status_code,
+                after_reset=after_reset.status_code,
+            )
+        """)
+
+    def test_repeated_failures_start_being_throttled(self):
+        self.assertIn(429, self.res['statuses'] + [self.res['throttled_status']])
+        self.assertEqual(self.res['throttled_status'], 429)
+
+    def test_the_wait_is_stated_in_the_body_and_the_header(self):
+        # Without it the app can only offer "try again", and the user taps.
+        self.assertIsNotNone(self.res['retry_after'])
+        self.assertIn('Try again in', self.res['throttled_error'])
+
+    def test_the_browser_form_shares_the_same_ladder(self):
+        self.assertEqual(self.res['form_status'], 429)
+
+    def test_a_correct_password_works_once_the_window_passes(self):
+        self.assertEqual(self.res['after_reset'], 200)
+
+
+class TestDisabledSurfaces(unittest.TestCase):
+    """Both switches that turn this endpoint off, and how it says so."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.without_secret = _run_mobile("""
+            database.claim_first_local_admin('boss', hashed())
+            resp = login('boss')
+            emit(status=resp.status_code,
+                 error=resp.get_json().get('error'),
+                 enabled=mobile_auth.mobile_auth_enabled())
+        """, JWT_SECRET_KEY='')
+
+        cls.under_sso = _run_mobile("""
+            database.create_local_user('boss', hashed(), is_admin=True)
+            resp = login('boss')
+            emit(status=resp.status_code,
+                 error=resp.get_json().get('error'),
+                 has_token='access_token' in resp.get_json())
+        """, AUTH_MODE='authentik',
+             AUTHENTIK_CLIENT_ID='cid', AUTHENTIK_CLIENT_SECRET='secret')
+
+    def test_without_a_signing_key_it_is_unavailable(self):
+        self.assertFalse(self.without_secret['enabled'])
+        self.assertEqual(self.without_secret['status'], 503)
+        self.assertIn('JWT_SECRET_KEY', self.without_secret['error'])
+
+    def test_under_authentik_a_password_is_refused(self):
+        # Group membership governs access there, not the password an account may
+        # happen to carry, so honouring one would go around single sign-on.
+        self.assertEqual(self.under_sso['status'], 400)
+        self.assertFalse(self.under_sso['has_token'])
+        self.assertIn('single sign-on', self.under_sso['error'])
+
+
+class TestStatusTellsTheAppWhichWayIn(unittest.TestCase):
+    """The app reads /api/auth/status before offering a form or a button."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.local = _run_mobile("""
+            fresh = app.test_client().get('/api/auth/status').get_json()
+            database.claim_first_local_admin('boss', hashed())
+            ready = app.test_client().get('/api/auth/status').get_json()
+            emit(fresh=fresh, ready=ready)
+        """)
+
+        cls.sso = _run_mobile("""
+            emit(status=app.test_client().get('/api/auth/status').get_json())
+        """, AUTH_MODE='authentik',
+             AUTHENTIK_CLIENT_ID='cid', AUTHENTIK_CLIENT_SECRET='secret')
+
+    def test_status_is_readable_without_a_session(self):
+        # It has to be: it is what the app asks before it has any credential.
+        self.assertIsNotNone(self.local['fresh'])
+
+    def test_a_fresh_local_instance_asks_for_setup(self):
+        fresh = self.local['fresh']
+        self.assertTrue(fresh['setup_required'])
+        self.assertTrue(fresh['local_auth_enabled'])
+        self.assertFalse(fresh['sso_enabled'])
+        self.assertTrue(fresh['mobile_auth_enabled'])
+
+    def test_setup_required_clears_once_an_account_exists(self):
+        self.assertFalse(self.local['ready']['setup_required'])
+
+    def test_an_sso_instance_advertises_the_browser_flow_only(self):
+        status = self.sso['status']
+        self.assertTrue(status['sso_enabled'])
+        self.assertFalse(status['local_auth_enabled'])
+        self.assertFalse(status['setup_required'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ui/README.md
+++ b/ui/README.md
@@ -80,7 +80,10 @@ Sign-in is always required. `AUTH_MODE` picks where accounts come from:
 
 The Android app in `../mobile/` uses JWT bearer tokens instead of cookies,
 enabled by setting `JWT_SECRET_KEY`. Bearer and cookie auth run side by side on
-the existing endpoints, with cookies taking precedence.
+the existing endpoints, with cookies taking precedence. It picks its sign-in from
+`/api/auth/status`: `POST /api/mobile/auth/login` for local accounts, or the
+browser handshake for Authentik. Both modes are covered, so the published APK
+works against an instance with no identity provider.
 
 See the [root README](../README.md#authentication) for the full setup.
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -771,19 +771,23 @@ def api_setup():
     return jsonify({'user': user['username'], 'is_admin': True})
 
 
-@app.route('/auth/local/login', methods=['POST'])
-def auth_local_login():
-    """Sign in with a username and password held by this app."""
-    if not LOCAL_AUTH:
-        return _login_failed('Password sign-in is disabled on this instance.', 400)
-    if _setup_required():
-        return redirect(url_for('setup'))
+class _LoginRejected(Exception):
+    """A refused sign-in, carrying what the client should be told."""
 
-    payload = request.get_json(silent=True) if request.is_json else None
-    source = payload if isinstance(payload, dict) else request.form
-    username = str(source.get('username') or '').strip()
-    password = str(source.get('password') or '')
+    def __init__(self, message: str, status: int, retry_after: int | None = None):
+        super().__init__(message)
+        self.message = message
+        self.status = status
+        self.retry_after = retry_after
 
+
+def _authenticate_password(username: str, password: str) -> dict:
+    """Return the account for valid credentials, or raise _LoginRejected.
+
+    Shared by the browser form and the Android app so both are slowed by the
+    same throttle ladder — otherwise the app endpoint would be an unthrottled
+    way around the form's.
+    """
     # Keyed on both, so guessing many passwords for one account and one password
     # across many accounts are both slowed. The client cannot influence the key
     # beyond the username it is already trying.
@@ -792,11 +796,9 @@ def auth_local_login():
     if wait > 0:
         auth_log.warning('sign-in throttled for %r from %s',
                          username, _client_ip())
-        return _login_failed(
+        raise _LoginRejected(
             f'Too many attempts. Try again in {int(wait) + 1} seconds.',
-            429,
-            retry_after=int(wait) + 1,
-        )
+            429, retry_after=int(wait) + 1)
 
     # Logged as separate reasons on purpose. The response cannot distinguish
     # them without telling an attacker which usernames exist, but the operator
@@ -810,22 +812,43 @@ def auth_local_login():
         login_throttle.record_failure(throttle_key)
         auth_log.warning('sign-in failed: no such account %r from %s',
                          username, _client_ip())
-        return _login_failed(_INVALID_CREDENTIALS, 401)
+        raise _LoginRejected(_INVALID_CREDENTIALS, 401)
 
     if not passwords.verify(user.get('password_hash'), password):
         login_throttle.record_failure(throttle_key)
         auth_log.warning('sign-in failed: wrong password for %s from %s',
                          user['username'], _client_ip())
-        return _login_failed(_INVALID_CREDENTIALS, 401)
+        raise _LoginRejected(_INVALID_CREDENTIALS, 401)
 
     login_throttle.reset(throttle_key)
-    auth_log.info('signed in: %s from %s', user['username'], _client_ip())
 
     # Cost parameters may have risen since this hash was stored; the password is
     # in hand exactly once, so this is the only chance to upgrade it.
     if passwords.needs_rehash(user['password_hash']):
         set_user_password(user['username'], passwords.hash_password(password))
+    return user
 
+
+@app.route('/auth/local/login', methods=['POST'])
+def auth_local_login():
+    """Sign in with a username and password held by this app."""
+    if not LOCAL_AUTH:
+        return _login_failed('Password sign-in is disabled on this instance.', 400)
+    if _setup_required():
+        return redirect(url_for('setup'))
+
+    payload = request.get_json(silent=True) if request.is_json else None
+    source = payload if isinstance(payload, dict) else request.form
+    username = str(source.get('username') or '').strip()
+    password = str(source.get('password') or '')
+
+    try:
+        user = _authenticate_password(username, password)
+    except _LoginRejected as rejected:
+        return _login_failed(rejected.message, rejected.status,
+                             retry_after=rejected.retry_after)
+
+    auth_log.info('signed in: %s from %s', user['username'], _client_ip())
     _establish_session(user['username'], is_admin=bool(user['is_admin']))
     if _wants_json():
         return jsonify({
@@ -1594,9 +1617,50 @@ def api_auth_status():
 
 
 # ===== Mobile (Android app) auth =====
-# The app cannot hold the OIDC client secret, so it opens the system browser
-# against Authentik and the server completes the code exchange, handing back a
-# JWT pair over a custom-scheme deep link. Disabled unless JWT_SECRET_KEY is set.
+# Two ways in, matching the two AUTH_MODEs. Under `local` the app posts a
+# username and password straight to /api/mobile/auth/login. Under `authentik`
+# the app cannot hold the OIDC client secret, so it opens the system browser and
+# the server completes the code exchange, handing back a JWT pair over a
+# custom-scheme deep link. Both are disabled unless JWT_SECRET_KEY is set.
+
+@app.route('/api/mobile/auth/login', methods=['POST'])
+def api_mobile_password_login():
+    """Exchange a username and password for a token pair.
+
+    Only under AUTH_MODE=local. Under Authentik the password, if an account even
+    has one, is not what governs access — group membership is — so accepting one
+    here would be a way around single sign-on.
+    """
+    if not mobile_auth.mobile_auth_enabled():
+        return jsonify({'error': 'Mobile auth is not configured. Set JWT_SECRET_KEY.'}), 503
+    if not LOCAL_AUTH:
+        return jsonify({
+            'error': 'This server uses single sign-on. Sign in with Authentik.',
+        }), 400
+    if _setup_required():
+        return jsonify({
+            'error': 'This server has no account yet. Open it in a browser to '
+                     'finish setup.',
+            'setup_required': True,
+        }), 409
+
+    payload = request.get_json(silent=True)
+    source = payload if isinstance(payload, dict) else {}
+    username = str(source.get('username') or '').strip()
+    password = str(source.get('password') or '')
+
+    try:
+        user = _authenticate_password(username, password)
+    except _LoginRejected as rejected:
+        response = jsonify({'error': rejected.message})
+        if rejected.retry_after is not None:
+            response.headers['Retry-After'] = str(rejected.retry_after)
+        return response, rejected.status
+
+    auth_log.info('app sign-in: %s from %s', user['username'], _client_ip())
+    return jsonify(mobile_auth.issue_token_pair(
+        user['username'], is_admin=bool(user['is_admin'])))
+
 
 @app.route('/api/mobile/auth/login-url', methods=['GET'])
 def api_mobile_login_url():


### PR DESCRIPTION
## Why

We are about to publish an APK on the releases page, and the app was not fit to be published:

- **The server address was compiled in** (`https://recipes.pickel.me`). Every downloader would have got an app pointing at one particular instance.
- **Authentik was the only way in.** Local accounts are now the default server mode, so most self-hosters would have installed the app and found no way to sign in.

## What changed

**The address is entered in the app**, on first launch, and kept on the device. It types short — `https://` is assumed, a trailing slash is dropped, a port or subpath is kept, credentials smuggled into the URL are discarded. Nothing is saved until the address answers `/api/auth/status`, so a typo leaves the form on screen rather than stranding the app somewhere it can never reach. A host that answers with something *else* (a router admin page, an unrelated app on that port) is rejected with a message about the address rather than about authentication. **Change** returns to the form and clears the stored tokens with it, since a token minted by one server means nothing to another.

**The sign-in method comes from the server.** The app reads `/api/auth/status` and offers exactly one of:

| Server state | What the app shows |
|---|---|
| `AUTH_MODE=local` | Username and password form |
| `AUTH_MODE=authentik` | The existing browser handshake |
| No account yet | Prompt to finish setup in a browser, plus a re-check button |
| `JWT_SECRET_KEY` unset | An explanation of what the operator needs to set |
| `authentik` with no credentials | An explanation that the server has no way in configured |

**`POST /api/mobile/auth/login`** is the new local path. It shares `_authenticate_password` with the browser form, so both are slowed by the *same* throttle ladder keyed on (IP, username) — otherwise the app endpoint would have been an unthrottled way around the form's. Wrong password and unknown account stay indistinguishable. Refused under `AUTH_MODE=authentik`, where group membership governs access rather than whatever password an account happens to carry; refused with `setup_required` before the first account exists, so the app can send the user to a browser instead of claiming bad credentials.

**Plain `http://` is allowed**, because self-hosted instances on a home network are common and refusing would leave those users with no app at all — but the address is shown with an open padlock and the password form states that the password will travel unencrypted.

`--dart-define=API_BASE_URL` now only *prefills* the field, keeping the emulator's `10.0.2.2` one tap away in dev. Release builds prefill nothing.

## Tests

- `tests/test_mobile_password_login.py`, 17 cases: the token pair and that it opens the app endpoints, admin rights carried and not invented, the refusals, the shared throttle ladder in both directions, both disable switches, and what `/api/auth/status` tells the app in each mode.
- Flutter, 30 new cases: URL normalisation including the IPv6 and credentials-in-URL edges, connect/restore/recheck/forget, nothing saved on an unreachable address, the address kept when a server is merely down, and password sign-in including throttle passthrough and double-submit.

185 server tests and 69 Flutter tests pass; `flutter analyze` clean; debug APK builds.

Also verified live against a local server: pre-setup 409, sign-in, bearer against `/api/mobile/me` and `/api/jobs`, and the throttle ladder shared with the web form.

## Test plan

- [ ] Fresh install: enter your server address, confirm a typo is rejected without being saved
- [ ] On a `local` instance, sign in with username and password
- [ ] On an `authentik` instance, confirm the browser button appears instead
- [ ] Tap Change, enter the other instance, confirm you are asked to sign in again
- [ ] Point at an instance with no account and confirm the setup prompt appears

Made with [Cursor](https://cursor.com)