### PR TITLE
fix(mobile): let the app reach plain-HTTP self-hosted instances

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -33,7 +33,15 @@ The app then reads `GET /api/auth/status` and offers only what that server has:
 
 A plain-`http://` address is allowed — plenty of self-hosted instances are HTTP
 on a home network, and refusing would leave those users with no app — but the
-password form says plainly that the password will travel unencrypted.
+address is shown with an open padlock and the password form says plainly that the
+password will travel unencrypted.
+
+That required permitting cleartext in `res/xml/network_security_config.xml`,
+which is a deliberate exception to the HTTPS-only default: Android's policy takes
+exact hosts rather than CIDR blocks, so "cleartext only on a private network"
+cannot be expressed. Certificate validation is *not* relaxed — a self-signed
+HTTPS certificate is still rejected, and the app says so rather than failing
+silently.
 
 ## Running
 
@@ -45,9 +53,7 @@ flutter run --dart-define=API_BASE_URL=http://192.168.1.10:5006   # prefill a ho
 
 `10.0.2.2` is the Android emulator's alias for the host machine; on a physical
 device use your machine's LAN address. Both only *prefill* the address field —
-the value the app uses is the one entered and stored on the device. Cleartext
-HTTP is permitted only for loopback/dev hosts; see
-`android/app/src/main/res/xml/network_security_config.xml`.
+the value the app uses is the one entered and stored on the device.
 
 ```bash
 flutter test

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Production traffic is HTTPS-only. Cleartext is permitted only for
-         local development hosts (Android emulator host alias / localhost). -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">127.0.0.1</domain>
-    </domain-config>
-    <base-config cleartextTrafficPermitted="false" />
+    <!-- Cleartext is permitted, which is a deliberate exception to the
+         HTTPS-only default.
+
+         This app connects to a server the user names at runtime, and a large
+         share of self-hosted Pick-a-Recipe instances are plain HTTP on a home
+         network. Android's policy cannot express "cleartext only for private
+         address ranges" — it takes exact hosts, not CIDR blocks — so the choice
+         is between permitting cleartext and shipping an app those users cannot
+         connect to at all.
+
+         The trade-off is surfaced rather than hidden: the sign-in screen marks
+         an http:// address with an open padlock and states that the password
+         will travel unencrypted. HTTPS remains what an address without a scheme
+         resolves to, so the short form nobody thinks about is the safe one.
+
+         Certificate validation is NOT relaxed anywhere: a self-signed HTTPS
+         certificate is still rejected, and the app says so. -->
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>


### PR DESCRIPTION
## Why

Found while getting ready to tag v1.6.0. `res/xml/network_security_config.xml` permitted cleartext only for `10.0.2.2` and loopback — correct back when the server address was compiled in and always HTTPS.

Now that the address is typed by the user, a release build would refuse `http://192.168.1.10:5006` at the platform level, *before* the app's own warning about cleartext was ever reached, and surface it as "Could not reach that server." The HTTP support added in #25 would have been broken in exactly the case it was added for.

## What changed

Cleartext is permitted generally. Android's network security policy takes exact hosts, not CIDR blocks, so "cleartext only for private address ranges" cannot be expressed — the choice is between permitting it and shipping an app that a large share of self-hosted instances cannot connect to.

What is *not* given up:

- Certificate validation is untouched. A self-signed HTTPS certificate is still rejected, with a message saying so rather than a silent failure.
- An address typed without a scheme still resolves to `https://`, so the short form nobody thinks about is the safe one.
- The sign-in screen marks an `http://` address with an open padlock, and the password form states the password will travel unencrypted.

## Verification

Unpacked the built APK and confirmed the packaged config, rather than trusting the source file:

```
E: network-security-config
E: base-config
    cleartextTrafficPermitted=true
```

`flutter analyze` clean, 69 Flutter tests pass.

Made with [Cursor](https://cursor.com)